### PR TITLE
make sorting of modules independent of locale

### DIFF
--- a/Hadrons/make_module_list.sh
+++ b/Hadrons/make_module_list.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 echo 'modules_cpp =\' > modules.inc
-find Modules -name '*.cpp' -type f -print | sort | sed 's/^/  /;$q;s/$/ \\/' >> modules.inc
+find Modules -name '*.cpp' -type f -print | LC_ALL=C sort | sed 's/^/  /;$q;s/$/ \\/' >> modules.inc
 echo '' >> modules.inc
 echo 'modules_hpp =\' >> modules.inc
-find Modules -name '*.hpp' -type f -print | sort | sed 's/^/  /;$q;s/$/ \\/' >> modules.inc
+find Modules -name '*.hpp' -type f -print | LC_ALL=C sort | sed 's/^/  /;$q;s/$/ \\/' >> modules.inc
 echo '' >> modules.inc
 rm -f Modules.hpp
-for f in $(find Modules -name '*.hpp' | sort); do
+for f in $(find Modules -name '*.hpp' | LC_ALL=C sort); do
 	echo "#include <Hadrons/${f}>" >> Modules.hpp
 done


### PR DESCRIPTION
The output of the sort command depends on language settings.
To resolve this issue, I have prepended the sort command with LC_ALL=C.

E. g.:
$ cat file | sort
 #include <Hadrons/Modules/MAction/ScaledDWF.hpp>
 #include <Hadrons/Modules/MAction/WilsonClover.hpp>
 #include <Hadrons/Modules/MAction/Wilson.hpp>
 #include <Hadrons/Modules/MAction/ZMobiusDWF.hpp>
$ cat file | LC_ALL=C sort
 #include <Hadrons/Modules/MAction/ScaledDWF.hpp>
 #include <Hadrons/Modules/MAction/Wilson.hpp>
 #include <Hadrons/Modules/MAction/WilsonClover.hpp>
 #include <Hadrons/Modules/MAction/ZMobiusDWF.hpp>

The output of LC_ALL=C sort is compatible with what is currently found in the repository.