### PR TITLE
Ignore all build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/build
+/build*
 /.buildutils
 /.vscode
 /autom4te.cache


### PR DESCRIPTION
Update .gitignore so that any directory starting with build is ignored.
Useful for multiple side-by-side configurations, e.g. CPU / GPU