### PR TITLE
bugfix in baryon 2pt functions using SlicedPropagators

### DIFF
--- a/Hadrons/Modules/MContraction/Baryon.hpp
+++ b/Hadrons/Modules/MContraction/Baryon.hpp
@@ -250,7 +250,7 @@ void TBaryon<FImpl1, FImpl2, FImpl3>::execute(void)
         
             LOG(Message) << "(propagator already sinked)" << std::endl;
             r.corr.clear();
-            for (unsigned int t = 0; t < buf.size(); ++t)
+            for (unsigned int t = 0; t < nt; ++t)
             {
                 cs = Zero();
                 for (int iQ1 = 0; iQ1 < nQ; iQ1++){


### PR DESCRIPTION
This was a bug in the 2pt functions when using SlicedPropagator (already sinked) fields as input. buf.size() was 0 at this stage, and therefore the contraction never computed, and the result always empty. As far as I'm aware, this part of the code hasn't been used in production so far.