### PR TITLE
Bugfix/module template

### DIFF
--- a/Hadrons/Modules/templates/Module_in_NS.cpp.template
+++ b/Hadrons/Modules/templates/Module_in_NS.cpp.template
@@ -1,0 +1,40 @@
+#include <Hadrons/Modules/___NAMESPACE___/___FILEBASENAME___.hpp>
+
+using namespace Grid;
+using namespace Hadrons;
+using namespace ___NAMESPACE___;
+
+/******************************************************************************
+*                  T___FILEBASENAME___ implementation                             *
+******************************************************************************/
+// constructor /////////////////////////////////////////////////////////////////
+T___FILEBASENAME___::T___FILEBASENAME___(const std::string name)
+: Module<___FILEBASENAME___Par>(name)
+{}
+
+// dependencies/products ///////////////////////////////////////////////////////
+std::vector<std::string> T___FILEBASENAME___::getInput(void)
+{
+    std::vector<std::string> in;
+    
+    return in;
+}
+
+std::vector<std::string> T___FILEBASENAME___::getOutput(void)
+{
+    std::vector<std::string> out = {getName()};
+    
+    return out;
+}
+
+// setup ///////////////////////////////////////////////////////////////////////
+void T___FILEBASENAME___::setup(void)
+{
+
+}
+
+// execution ///////////////////////////////////////////////////////////////////
+void T___FILEBASENAME___::execute(void)
+{
+
+}

--- a/Hadrons/Modules/templates/Module_tmp_in_NS.cpp.template
+++ b/Hadrons/Modules/templates/Module_tmp_in_NS.cpp.template
@@ -1,0 +1,7 @@
+#include <Hadrons/Modules/___NAMESPACE___/___FILEBASENAME___.hpp>
+
+using namespace Grid;
+using namespace Hadrons;
+using namespace ___NAMESPACE___;
+
+template class Grid::Hadrons::___NAMESPACE___::T___FILEBASENAME___<FIMPL>;

--- a/Hadrons/add_module.sh
+++ b/Hadrons/add_module.sh
@@ -8,15 +8,15 @@ NAME=$1
 NS=$2
 
 mkdir -p Modules/${NS}
-if [ -e "Modules/${NS}/${NAME}.cc" ] || [ -e "Modules/${NS}/${NAME}.hpp" ]; then
+if [ -e "Modules/${NS}/${NAME}.cpp" ] || [ -e "Modules/${NS}/${NAME}.hpp" ]; then
 	echo "error: files Modules/${NS}/${NAME}.* already exists" 1>&2
 	exit 1
 fi
-TMPCC=".${NS}.${NAME}.tmp.cc"
+TMPCC=".${NS}.${NAME}.tmp.cpp"
 TMPHPP=".${NS}.${NAME}.tmp.hpp"
-sed "s/___FILEBASENAME___/${NAME}/g" Modules/templates/Module_in_NS.cc.template  > ${TMPCC}
+sed "s/___FILEBASENAME___/${NAME}/g" Modules/templates/Module_in_NS.cpp.template  > ${TMPCC}
 sed "s/___FILEBASENAME___/${NAME}/g" Modules/templates/Module_in_NS.hpp.template > ${TMPHPP}
-sed "s/___NAMESPACE___/${NS}/g" ${TMPCC}  > Modules/${NS}/${NAME}.cc
+sed "s/___NAMESPACE___/${NS}/g" ${TMPCC}  > Modules/${NS}/${NAME}.cpp
 sed "s/___NAMESPACE___/${NS}/g" ${TMPHPP} > Modules/${NS}/${NAME}.hpp
 rm -f ${TMPCC} ${TMPHPP}
 ./make_module_list.sh

--- a/Hadrons/add_module_template.sh
+++ b/Hadrons/add_module_template.sh
@@ -8,15 +8,15 @@ NAME=$1
 NS=$2
 
 mkdir -p Modules/${NS}
-if [ -e "Modules/${NS}/${NAME}.cc" ] || [ -e "Modules/${NS}/${NAME}.hpp" ]; then
+if [ -e "Modules/${NS}/${NAME}.cpp" ] || [ -e "Modules/${NS}/${NAME}.hpp" ]; then
 	echo "error: files Modules/${NS}/${NAME}.* already exists" 1>&2
 	exit 1
 fi
-TMPCC=".${NS}.${NAME}.tmp.cc"
+TMPCC=".${NS}.${NAME}.tmp.cpp"
 TMPHPP=".${NS}.${NAME}.tmp.hpp"
-sed "s/___FILEBASENAME___/${NAME}/g" Modules/templates/Module_tmp_in_NS.cc.template  > ${TMPCC}
+sed "s/___FILEBASENAME___/${NAME}/g" Modules/templates/Module_tmp_in_NS.cpp.template  > ${TMPCC}
 sed "s/___FILEBASENAME___/${NAME}/g" Modules/templates/Module_tmp_in_NS.hpp.template > ${TMPHPP}
-sed "s/___NAMESPACE___/${NS}/g" ${TMPCC}  > Modules/${NS}/${NAME}.cc
+sed "s/___NAMESPACE___/${NS}/g" ${TMPCC}  > Modules/${NS}/${NAME}.cpp
 sed "s/___NAMESPACE___/${NS}/g" ${TMPHPP} > Modules/${NS}/${NAME}.hpp
 rm -f ${TMPCC} ${TMPHPP}
 ./make_module_list.sh


### PR DESCRIPTION
It seems like all modules now have a .cpp  file, as opposed to a .cc file like in older versions. The two scripts to add a module still created .cc files. 

NB: I just changed the file-suffix and checked that (empty) modules created with the script compile. If anything else changed in the conventions, please do not approve this pull request!