### PR TITLE
Use CXX and CXXLD that Grid chose to use

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,8 +21,12 @@ AC_CHECK_PROG([GRIDCONF],[grid-config],[yes])
 if test x"$GRIDCONF" != x"yes" ; then
     AC_MSG_ERROR([grid-config not found])
 fi
-CXX="`grid-config --cxx`"
-CXXLD="`grid-config --cxxld`"
+if test x"$CXX" == x ; then
+    CXX="`grid-config --cxx`"
+fi
+if test x"$CXXLD" == x ; then
+    CXXLD="`grid-config --cxxld`"
+fi
 CXXFLAGS="$CXXFLAGS `grid-config --cxxflags`"
 LDFLAGS="$LDFLAGS `grid-config --ldflags`"
 CXXFLAGS="$AM_CXXFLAGS $CXXFLAGS"
@@ -55,6 +59,7 @@ AC_LINK_IFELSE(
     [AC_MSG_ERROR([impossible to compile a minimal Grid program])])
 
 HADRONS_CXX="$CXX"
+HADRONS_CXXLD="$CXXLD"
 HADRONS_CXXFLAGS="$CXXFLAGS"
 HADRONS_LDFLAGS="$LDFLAGS"
 HADRONS_LIBS="$LIBS"
@@ -65,6 +70,7 @@ AC_SUBST([CXXLD])
 AC_SUBST([AM_CXXFLAGS])
 AC_SUBST([AM_LDFLAGS])
 AC_SUBST([HADRONS_CXX])
+AC_SUBST([HADRONS_CXXLD])
 AC_SUBST([HADRONS_CXXFLAGS])
 AC_SUBST([HADRONS_LDFLAGS])
 AC_SUBST([HADRONS_LIBS])

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,8 @@ AC_CHECK_PROG([GRIDCONF],[grid-config],[yes])
 if test x"$GRIDCONF" != x"yes" ; then
     AC_MSG_ERROR([grid-config not found])
 fi
+CXX="`grid-config --cxx`"
+CXXLD="`grid-config --cxxld`"
 CXXFLAGS="$CXXFLAGS `grid-config --cxxflags`"
 LDFLAGS="$LDFLAGS `grid-config --ldflags`"
 CXXFLAGS="$AM_CXXFLAGS $CXXFLAGS"
@@ -59,6 +61,7 @@ HADRONS_LIBS="$LIBS"
 HADRONS_SHA=`git rev-parse HEAD`
 HADRONS_BRANCH=`git rev-parse --abbrev-ref HEAD`
 
+AC_SUBST([CXXLD])
 AC_SUBST([AM_CXXFLAGS])
 AC_SUBST([AM_LDFLAGS])
 AC_SUBST([HADRONS_CXX])

--- a/hadrons-config.in
+++ b/hadrons-config.in
@@ -18,6 +18,8 @@ Known values for OPTION are:
   --help       display this help and exit
   --version    output version information
   --git        print git revision
+  --cxx        print c++ compiler (may include some flags and spaces)
+  --cxxld      print c++ linker   (may include some flags and spaces)
 
 EOF
   
@@ -62,6 +64,10 @@ while test $# -gt 0; do
     
     --cxx)
       echo @HADRONS_CXX@
+    ;;
+    
+    --cxxld)
+      echo @HADRONS_CXXLD@
     ;;
     
     --ldflags)


### PR DESCRIPTION
Small tweak to facilitate Hadrons builds targeting GPU: i.e. ensure we use the same c++ compiler and linker that Grid used