### PR TITLE
Tweaks for GPU Build

### DIFF
--- a/Hadrons/DilutedNoise.hpp
+++ b/Hadrons/DilutedNoise.hpp
@@ -325,7 +325,8 @@ void SparseSpinColorDiagonalNoise<FImpl>::generateNoise(GridParallelRNG &rng)
                 LatticeCoordinate(coor, d);
                 coorTot = coorTot + coor;
             }
-            coorTot = coorTot + j;
+            coor = j;
+            coorTot = coorTot + coor;
             eta = where(mod(coorTot,nSparse_), 0.*eta, eta);
             
         }

--- a/configure.ac
+++ b/configure.ac
@@ -23,9 +23,13 @@ if test x"$GRIDCONF" != x"yes" ; then
 fi
 if test x"$CXX" == x ; then
     CXX="`grid-config --cxx`"
+elif test "$CXX" != "`grid-config --cxx`" ; then
+    AC_MSG_WARN([CXX differs from that reported by grid-config])
 fi
 if test x"$CXXLD" == x ; then
     CXXLD="`grid-config --cxxld`"
+elif test "$CXXLD" != "`grid-config --cxxld`" ; then
+    AC_MSG_WARN([CXXLD differs from that reported by grid-config])
 fi
 CXXFLAGS="$CXXFLAGS `grid-config --cxxflags`"
 LDFLAGS="$LDFLAGS `grid-config --ldflags`"


### PR DESCRIPTION
Tweaks to:
a) workaround possible LatticeInteger issue;
b) warn when …Hadrons uses different compiler / linker to Grid (as this will happen by default if c++ compiler sets CXX environment variable)