### PR TITLE
Bugfix/et go home

### DIFF
--- a/Hadrons/Modules/MDistil/DistilVectors.hpp
+++ b/Hadrons/Modules/MDistil/DistilVectors.hpp
@@ -145,11 +145,11 @@ void TDistilVectors<FImpl>::setup(void)
     GridCartesian * const grid4d{env().getGrid()};
     MakeLowerDimGrid(grid3d, grid4d);
     
-    envTmp(LatticeSpinColourVector, "source4d",1,LatticeSpinColourVector(grid4d));
-    envTmp(LatticeSpinColourVector, "source3d",1,LatticeSpinColourVector(grid3d.get()));
-    envTmp(LatticeColourVector, "source3d_nospin",1,LatticeColourVector(grid3d.get()));
-    envTmp(LatticeSpinColourVector, "sink3d",1,LatticeSpinColourVector(grid3d.get()));
-    envTmp(LatticeColourVector, "evec3d",1,LatticeColourVector(grid3d.get()));
+    envTmpLat(LatticeSpinColourVector, "source4d");
+    envTmp(LatticeSpinColourVector,    "source3d", 1, grid3d.get());
+    envTmp(LatticeColourVector, "source3d_nospin", 1, grid3d.get());
+    envTmp(LatticeSpinColourVector,      "sink3d", 1, grid3d.get());
+    envTmp(LatticeColourVector,          "evec3d", 1, grid3d.get());
 }
 
 // execution ///////////////////////////////////////////////////////////////////

--- a/Hadrons/Modules/MDistil/LapEvec.hpp
+++ b/Hadrons/Modules/MDistil/LapEvec.hpp
@@ -158,7 +158,7 @@ void TLapEvec<GImpl>::setup(void)
     envTmpLat(GaugeField, "Umu_smear");
     envTmp(LatticeGaugeField, "UmuNoTime", 1, gridLD.get());
     envTmp(LatticeColourVector,     "src", 1, gridLD.get());
-    envTmp(Grid::Vector<LapEvecs>,  "eig", 1, Ntlocal);
+    envTmp(std::vector<LapEvecs>,  "eig", 1, Ntlocal);
     // Output objects
     envCreate(LapEvecs, getName(), 1, par().Lanczos.Nvec, gridHD);
 }

--- a/Hadrons/Modules/MDistil/LapEvec.hpp
+++ b/Hadrons/Modules/MDistil/LapEvec.hpp
@@ -156,9 +156,9 @@ void TLapEvec<GImpl>::setup(void)
     // Temporaries
     envTmpLat(GaugeField, "Umu_stout");
     envTmpLat(GaugeField, "Umu_smear");
-    envTmp(LatticeGaugeField, "UmuNoTime",1,LatticeGaugeField(gridLD.get()));
-    envTmp(LatticeColourVector, "src",1,LatticeColourVector(gridLD.get()));
-    envTmp(std::vector<LapEvecs>, "eig",1,std::vector<LapEvecs>(Ntlocal));
+    envTmp(LatticeGaugeField, "UmuNoTime", 1, gridLD.get());
+    envTmp(LatticeColourVector,     "src", 1, gridLD.get());
+    envTmp(Grid::Vector<LapEvecs>,  "eig", 1, Ntlocal);
     // Output objects
     envCreate(LapEvecs, getName(), 1, par().Lanczos.Nvec, gridHD);
 }

--- a/Hadrons/Modules/MDistil/PerambFromSolve.hpp
+++ b/Hadrons/Modules/MDistil/PerambFromSolve.hpp
@@ -122,8 +122,8 @@ void TPerambFromSolve<FImpl>::setup(void)
     const int LI_reduced{  par().LI_reduced};
     envCreate(PerambTensor, getName(), 1, Nt,nvec_reduced,LI_reduced,dp.nnoise,Nt_inv,dp.SI);
     envCreate(NoiseTensor, getName() + "_noise", 1, dp.nnoise, Nt, dp.nvec, Ns );
-    envTmp(LatticeColourVector, "result3d_nospin",1,LatticeColourVector(grid3d.get()));
-    envTmp(LatticeColourVector, "evec3d",1,LatticeColourVector(grid3d.get()));
+    envTmp(LatticeColourVector, "result3d_nospin", 1, grid3d.get());
+    envTmp(LatticeColourVector, "evec3d",          1, grid3d.get());
     envTmpLat(LatticeColourVector, "result4d_nospin");
 }
 

--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -132,12 +132,12 @@ void TPerambulator<FImpl>::setup(void)
     
     envTmpLat(LatticeSpinColourVector,   "dist_source");
     envTmpLat(LatticeSpinColourVector,   "source4d");
-    envTmp(LatticeSpinColourVector,      "source3d",1,LatticeSpinColourVector(grid3d.get()));
-    envTmp(LatticeColourVector,          "source3d_nospin",1,LatticeColourVector(grid3d.get()));
+    envTmp(LatticeSpinColourVector,      "source3d",        1, grid3d.get());
+    envTmp(LatticeColourVector,          "source3d_nospin", 1, grid3d.get());
     envTmpLat(LatticeSpinColourVector,   "result4d");
     envTmpLat(LatticeColourVector,       "result4d_nospin");
-    envTmp(LatticeColourVector,          "result3d_nospin",1,LatticeColourVector(grid3d.get()));
-    envTmp(LatticeColourVector,          "evec3d",1,LatticeColourVector(grid3d.get()));
+    envTmp(LatticeColourVector,          "result3d_nospin", 1, grid3d.get());
+    envTmp(LatticeColourVector,          "evec3d",          1, grid3d.get());
     
     Ls_ = env().getObjectLs(par().solver);
     envTmpLat(FermionField, "v4dtmp");

--- a/Hadrons/NamedTensor.hpp
+++ b/Hadrons/NamedTensor.hpp
@@ -175,7 +175,7 @@ class NoiseTensor : public NamedTensor<Complex, 4>
     static const std::array<std::string, 4> DefaultIndexNames__;
     // Construct a named tensor explicitly specifying size of each dimension
     template<typename... IndexTypes>
-    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE NoiseTensor(Eigen::Index nNoise, Eigen::Index nT, Eigen::Index nVec, Eigen::Index nS)
+    NoiseTensor(Eigen::Index nNoise, Eigen::Index nT, Eigen::Index nVec, Eigen::Index nS)
     : NamedTensor{Name__, DefaultIndexNames__, nNoise, nT, nVec, nS} {}
 };
 
@@ -186,7 +186,7 @@ class PerambTensor : public NamedTensor<SpinVector, 6>
     static const std::array<std::string, 6> DefaultIndexNames__;
     // Construct a named tensor explicitly specifying size of each dimension
     template<typename... IndexTypes>
-    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE PerambTensor(Eigen::Index nT, Eigen::Index nVec, Eigen::Index LI, Eigen::Index nNoise, Eigen::Index nT_inv, Eigen::Index SI)
+    PerambTensor(Eigen::Index nT, Eigen::Index nVec, Eigen::Index LI, Eigen::Index nNoise, Eigen::Index nT_inv, Eigen::Index SI)
     : NamedTensor{Name__, DefaultIndexNames__, nT, nVec, LI, nNoise, nT_inv, SI} {}
 };
 
@@ -197,7 +197,7 @@ class TimesliceEvals : public NamedTensor<RealD, 2>
     static const std::array<std::string, 2> DefaultIndexNames__;
     // Construct a named tensor explicitly specifying size of each dimension
     template<typename... IndexTypes>
-    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE TimesliceEvals(Eigen::Index nT, Eigen::Index nVec)
+    TimesliceEvals(Eigen::Index nT, Eigen::Index nVec)
     : NamedTensor{Name__, DefaultIndexNames__, nT, nVec} {}
 };
 

--- a/Hadrons/NamedTensor.hpp
+++ b/Hadrons/NamedTensor.hpp
@@ -49,16 +49,6 @@ BEGIN_HADRONS_NAMESPACE
 
 extern const std::string NamedTensorFileExtension;
 
-// Return the product of a variable number of dimensions
-Eigen::Index NamedTensorSize() { return 1; }
-template<typename... IndexTypes>
-Eigen::Index NamedTensorSize(Eigen::Index firstDimension, IndexTypes... otherDimensions)
-{
-    if( sizeof...(otherDimensions) )
-        firstDimension *= NamedTensorSize( otherDimensions... );
-    return firstDimension;
-}
-
 template<typename Scalar_, int NumIndices_>
 class NamedTensor : Serializable
 {
@@ -78,6 +68,16 @@ public:
     // Name of the object and Index names as set in the constructor
     const std::string                          &Name_;
     const std::array<std::string, NumIndices_> &DefaultIndexNames_;
+
+    // Return the product of a variable number of dimensions
+    Eigen::Index NamedTensorSize() { return 1; }
+    template<typename... IndexTypes>
+    inline Eigen::Index NamedTensorSize(Eigen::Index firstDimension, IndexTypes... otherDimensions)
+    {
+        if( sizeof...(otherDimensions) )
+            firstDimension *= NamedTensorSize( otherDimensions... );
+        return firstDimension;
+    }
 
     // Construct a named tensor explicitly specifying size of each dimension
     template<typename... IndexTypes>


### PR DESCRIPTION
Ensure memory allocated for distillation objects tracked by Hadrons scheduler.
1) NamedTensor objects' memory allocated using Grid::alignedAllocator (and consequently GPU accessible but non-resizable)
2) Lower dimensional (3d) slice object constructors called while scheduler tracking memory allocation
NB: PRE-REQUISITE: Grid Bugfix/ET_go_home is a pre-requisite for this change