### PR TITLE
Implementing Database structure for kl2 contraction code

### DIFF
--- a/Hadrons/Modules/MContraction/WeakMesonDecayKl2.hpp
+++ b/Hadrons/Modules/MContraction/WeakMesonDecayKl2.hpp
@@ -97,6 +97,7 @@ public:
     // dependencies/products
     virtual std::vector<std::string> getInput(void);
     virtual std::vector<std::string> getOutput(void);
+    virtual std::vector<std::string> getOutputFiles(void);
 protected:
     // execution
     virtual void setup(void);
@@ -128,6 +129,14 @@ template <typename FImpl>
 std::vector<std::string> TWeakMesonDecayKl2<FImpl>::getOutput(void)
 {
     std::vector<std::string> output = {};
+    
+    return output;
+}
+
+template <typename FImpl>
+std::vector<std::string> TWeakMesonDecayKl2<FImpl>::getOutputFiles(void)
+{
+    std::vector<std::string> output = {resultFilename(par().output)};
     
     return output;
 }

--- a/Hadrons/VirtualMachine.hpp
+++ b/Hadrons/VirtualMachine.hpp
@@ -114,7 +114,7 @@ public:
     {
         HADRONS_SQL_FIELDS(SqlUnique<unsigned int>           , objectTypeId,
                            SqlUnique<SqlNotNull<std::string>>, type,
-                           SqlUnique<SqlNotNull<std::string>>, baseType);
+                           SqlNotNull<std::string>, baseType);
     };
 
     struct ScheduleEntry: SqlEntry


### PR DESCRIPTION
Summary:
 
1. added getOutputFiles in WeakMesonDecayKl2.hpp
2. in VirtualMachine.hpp: Changed baseType SqlUnique<SqlNotNull<std::string>> -> SqlNotNull<std::string> because WeakMesonDecayKl2.hpp has two different object 'type' that mutual baseType.

