### PR TITLE
Added momentum to disconnected loop module

### DIFF
--- a/Hadrons/Modules/MContraction/DiscLoop.hpp
+++ b/Hadrons/Modules/MContraction/DiscLoop.hpp
@@ -34,6 +34,21 @@
 
 BEGIN_HADRONS_NAMESPACE
 
+/*
+ 
+ Disconnected loop contractions
+ ------------------------------
+ 
+ * options:
+ - q_loop: input propagator (string)
+ - gammas: gammas: gamma matrices to insert
+           (space-separated strings e.g. "GammaT GammaX GammaY") 
+
+           Special values: "all" - perform all possible contractions.
+ - mom:    momentum insertion, vector of space-separated int sequence
+           (e.g {"0 0 0", "1 0 0", "0 2 0"})
+*/
+
 /******************************************************************************
  *                                DiscLoop                                    *
  ******************************************************************************/

--- a/Hadrons/Modules/MContraction/DiscLoop.hpp
+++ b/Hadrons/Modules/MContraction/DiscLoop.hpp
@@ -43,9 +43,10 @@ class DiscLoopPar: Serializable
 {
 public:
     GRID_SERIALIZABLE_CLASS_MEMBERS(DiscLoopPar,
-                                    std::string, q_loop,
-                                    std::string, gammas,
-                                    std::string, output);
+                                    std::string,              q_loop,
+                                    std::string,              gammas,
+                                    std::vector<std::string>, mom,
+                                    std::string,              output);
 };
 
 template <typename FImpl>
@@ -53,11 +54,13 @@ class TDiscLoop: public Module<DiscLoopPar>
 {
 public:
     FERM_TYPE_ALIASES(FImpl,);
+    typedef std::vector<SitePropagator> SlicedOp;
     class Result: Serializable
     {
     public:
         GRID_SERIALIZABLE_CLASS_MEMBERS(Result,
                                         Gamma::Algebra, gamma,
+                                        std::vector<int>, mom,
                                         std::vector<Complex>, corr);
     };
 public:
@@ -75,6 +78,8 @@ protected:
     virtual void setup(void);
     // execution
     virtual void execute(void);
+private:
+    std::vector<std::vector<int>> mom_;
 };
 
 MODULE_REGISTER_TMP(DiscLoop, TDiscLoop<FIMPL>, MContraction);
@@ -117,7 +122,23 @@ std::vector<std::string> TDiscLoop<FImpl>::getOutputFiles(void)
 template <typename FImpl>
 void TDiscLoop<FImpl>::setup(void)
 {
-    envTmpLat(LatticeComplex, "c");
+    const unsigned int nd = env().getDim().size();
+    mom_.resize(par().mom.size());
+    for (unsigned int i = 0; i < mom_.size(); ++i)
+    {
+        mom_[i] = strToVec<int>(par().mom[i]);
+        if (mom_[i].size() != nd - 1)
+        {
+            HADRONS_ERROR(Size, "momentum number of components different from " 
+                               + std::to_string(nd-1));
+        }
+        for (unsigned int j = 0; j < nd - 1; ++j)
+        {
+            mom_[i][j] = (mom_[i][j] + env().getDim(j)) % env().getDim(j);
+        }
+    }
+    envTmpLat(PropagatorField, "ftBuf");
+    envTmpLat(PropagatorField, "op");
 }
 
 template <typename FImpl>
@@ -146,31 +167,63 @@ void TDiscLoop<FImpl>::execute(void)
 {
     LOG(Message) << "Computing disconnected loop contraction '" << getName() 
                  << "' using '" << par().q_loop << "' with " << par().gammas 
-                 << " insertion." << std::endl;
+                 << " insertion and momentum " << par().mom
+                 << "." << std::endl;
 
-    auto                        &q_loop = envGet(PropagatorField, par().q_loop);
-    std::vector<Gamma::Algebra> gammaList;
-    std::vector<TComplex>       buf;
-    std::vector<Result>         result;
-    int                         nt = env().getDim(Tp);
+    const unsigned int                 nt      = env().getDim(Tp);
+    const unsigned int                 nd      = env().getDim().size();
+    const unsigned int                 nmom    = mom_.size();
+    auto                               &q_loop = envGet(PropagatorField, par().q_loop);
+    std::vector<Gamma::Algebra>        gammaList;
+    SitePropagator                           buf;
+    std::vector<std::vector<SlicedOp>> slicedOp;
+    std::vector<std::vector<Result>>   result;
+    FFT                                fft(envGetGrid(PropagatorField));
+    std::vector<int>                   dMask(nd, 1);
 
+    dMask[nd - 1] = 0;
+    envGetTmp(PropagatorField, ftBuf);
+    envGetTmp(PropagatorField, op);
     parseGammaString(gammaList);
-    result.resize(gammaList.size());
-    for (unsigned int i = 0; i < result.size(); ++i)
+    const unsigned int ngam = gammaList.size();
+    result.resize(ngam);
+    for (unsigned int g = 0; g < ngam; ++g)
     {
-        result[i].gamma = gammaList[i];
-        result[i].corr.resize(nt);
+        result[g].resize(nmom);
+        for (unsigned int m = 0; m < nmom; ++m)
+        {
+            result[g][m].gamma = gammaList[g];
+            result[g][m].mom   = mom_[m];
+            result[g][m].corr.resize(nt);
+        }
     }
 
-    envGetTmp(LatticeComplex, c);
-    for (unsigned int i = 0; i < result.size(); ++i)
+    slicedOp.resize(ngam);
+    for (unsigned int g = 0; g < ngam; ++g)
     {
-        Gamma gamma(gammaList[i]);
-        c = trace(gamma*q_loop);
-        sliceSum(c, buf, Tp);
-        for (unsigned int t = 0; t < buf.size(); ++t)
+        Gamma gamma(gammaList[g]);
+        op = gamma*q_loop;
+        fft.FFT_dim_mask(ftBuf, op, dMask, FFT::forward);
+        slicedOp[g].resize(nmom);
+        for (unsigned int m = 0; m < nmom; ++m)
         {
-            result[i].corr[t] = TensorRemove(buf[t]);
+            auto qt = mom_[m];
+            qt.resize(nd);
+            slicedOp[g][m].resize(nt);
+            for (unsigned int t = 0; t < nt; ++t)
+            {
+                qt[nd - 1] = t;
+                peekSite(buf, ftBuf, qt);
+                slicedOp[g][m][t] = buf;
+            }
+        }
+    }
+    for (unsigned int g = 0; g < ngam; ++g)
+    for (unsigned int m = 0; m < nmom; ++m)
+    {
+        for (unsigned int t = 0; t < nt; ++t)
+        {
+            result[g][m].corr[t] = TensorRemove(trace(slicedOp[g][m][t]));
         }
     }
     saveResult(par().output, "disc", result);

--- a/Hadrons/Modules/MContraction/DiscLoop.hpp
+++ b/Hadrons/Modules/MContraction/DiscLoop.hpp
@@ -175,7 +175,7 @@ void TDiscLoop<FImpl>::execute(void)
     const unsigned int                 nmom    = mom_.size();
     auto                               &q_loop = envGet(PropagatorField, par().q_loop);
     std::vector<Gamma::Algebra>        gammaList;
-    SitePropagator                           buf;
+    SitePropagator                     buf;
     std::vector<std::vector<SlicedOp>> slicedOp;
     std::vector<std::vector<Result>>   result;
     FFT                                fft(envGetGrid(PropagatorField));


### PR DESCRIPTION
The DiscLoop module now takes a vector of strings of momenta as an input. A FFT is performed for each gamma*prop_loop and the result for each momentum is found by peeking the appropriate site.

Tested this locally by comparing to sliceSum of zero and non-zero momentum phase multiplications on a unit gauge.