### PR TITLE
Bugfix/perambulator use GlobalSumVector() to share perambulator slices

### DIFF
--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -143,19 +143,6 @@ void TPerambulator<FImpl>::setup(void)
     envTmpLat(FermionField, "v5dtmp_sol", Ls_);
 }
 
-template <typename T> typename std::enable_if<!::Grid::EigenIO::is_complex<T>::value>::type
-GlobalSumHelper(GridCartesian * const grid,T * data,int N)
-{
-    grid->GlobalSumVector(data,N);
-}
-template <typename T> typename std::enable_if<::Grid::EigenIO::is_complex<T>::value>::type
-GlobalSumHelper(GridCartesian * const grid,T * data,int N)
-{
-    using Scalar = typename ::Grid::RealPart<T>::type;
-    Scalar * p = reinterpret_cast<Scalar *>( data );
-    grid->GlobalSumVector(p,2*N);
-}
-
 // execution ///////////////////////////////////////////////////////////////////
 template <typename FImpl>
 void TPerambulator<FImpl>::execute(void)
@@ -274,7 +261,7 @@ void TPerambulator<FImpl>::execute(void)
                 }
             }
         }
-        GlobalSumHelper(grid4d, PerambData, TensorSize);
+        grid4d->GlobalSumVector(PerambData, TensorSize);
     }
     
     // Save the perambulator to disk from the boss node

--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -7,7 +7,6 @@
  *  Author: Michael Marshall <Michael.Marshall@ed.ac.uk>
  * Author: Antonin Portelli <antonin.portelli@me.com>
  * Author: Felix Erben <dc-erbe1@tesseract-login1.ib0.sgi.cluster.dirac.ed.ac.uk>
- * Author: Michael Marshall <43034299+mmphys@users.noreply.github.com>
  * Author: ferben <ferben@debian.felix.com>
  *
  * Hadrons is free software: you can redistribute it and/or modify
@@ -250,7 +249,7 @@ void TPerambulator<FImpl>::execute(void)
         using InnerScalar = typename PerambTensor::Traits::scalar_type;
         InnerScalar * const PerambData {EigenIO::getFirstScalar( perambulator.tensor )};
         // Zero data for all timeslices other than the slice computed by 3d boss nodes
-        for (int Slice = 0 ; Slice < SliceCount ; ++Slice)
+        for (int Slice = 0 ; Slice < NumSlices ; ++Slice)
         {
             if (!grid3d->IsBoss() || Slice != MySlice)
             {


### PR DESCRIPTION
Have compared that perambulators are bit identical before and after this change.
See perambulator perambS_nvec3.1100.h5 on Tesseract ~dc-mars3/test:
* bugfix_perambulator_e064e49
* golden_7872548
(i.e. after change and before change - hex numbers are git commits)