### PR TITLE
Enable GPU builds

### DIFF
--- a/Hadrons/Modules/MContraction/Baryon.cpp
+++ b/Hadrons/Modules/MContraction/Baryon.cpp
@@ -30,5 +30,7 @@ using namespace Grid;
 using namespace Hadrons;
 using namespace MContraction;
 
+#if (!defined(GRID_CUDA)) && (!defined(GRID_HIP))
 template class Grid::Hadrons::MContraction::TBaryon<FIMPL>;
+#endif
 

--- a/Hadrons/Modules/MContraction/Baryon.hpp
+++ b/Hadrons/Modules/MContraction/Baryon.hpp
@@ -43,6 +43,7 @@ BEGIN_HADRONS_NAMESPACE
  ******************************************************************************/
 BEGIN_MODULE_NAMESPACE(MContraction)
 
+#if (!defined(GRID_CUDA)) && (!defined(GRID_HIP))
 typedef std::pair<Gamma::Algebra, Gamma::Algebra> GammaAB;
 typedef std::pair<GammaAB, GammaAB> GammaABPair;
 
@@ -483,6 +484,7 @@ void TBaryon<FImpl>::execute(void)
         saveResult(par().output + "_Matrix", "baryonMat", resultMat);
 
 }
+#endif
 
 END_MODULE_NAMESPACE
 

--- a/Hadrons/Modules/MContraction/BaryonGamma3pt.cpp
+++ b/Hadrons/Modules/MContraction/BaryonGamma3pt.cpp
@@ -31,5 +31,7 @@ using namespace Grid;
 using namespace Hadrons;
 using namespace MContraction;
 
+#if (!defined(GRID_CUDA)) && (!defined(GRID_HIP))
 template class Grid::Hadrons::MContraction::TBaryonGamma3pt<FIMPL>;
+#endif
 

--- a/Hadrons/Modules/MContraction/BaryonGamma3pt.hpp
+++ b/Hadrons/Modules/MContraction/BaryonGamma3pt.hpp
@@ -102,6 +102,7 @@ BEGIN_HADRONS_NAMESPACE
 BEGIN_MODULE_NAMESPACE(MContraction)
 
 
+#if (!defined(GRID_CUDA)) && (!defined(GRID_HIP))
 typedef std::pair<Gamma::Algebra, Gamma::Algebra> GammaAB;
 typedef std::pair<GammaAB, GammaAB> GammaABPair;
 
@@ -492,6 +493,7 @@ void TBaryonGamma3pt<FImpl>::execute(void)
     saveResult(par().output, "baryongamma3pt", result);
 }
 
+#endif
 END_MODULE_NAMESPACE
 
 END_HADRONS_NAMESPACE


### PR DESCRIPTION
Temporarily disable Baryon contraction modules so that CUDA and HIP builds can complete. This is temporary and a patch for these modules for GPU is nearing completion.