### PR TITLE
Add ability to save gauge-fixed (gauge) fields and save/load colour matrix transform

### DIFF
--- a/Hadrons/Modules/MIO/LoadField.hpp
+++ b/Hadrons/Modules/MIO/LoadField.hpp
@@ -71,6 +71,7 @@ MODULE_REGISTER_TMP(LoadPropagator, TLoadField<FIMPL::PropagatorField>, MIO);
 #ifdef GRID_DEFAULT_PRECISION_DOUBLE
 MODULE_REGISTER_TMP(LoadPropagatorIo32, ARG(TLoadField<FIMPL::PropagatorField, FIMPLF::PropagatorField>), MIO);
 #endif
+MODULE_REGISTER_TMP(LoadColourMatrixField, TLoadField<GIMPL::GaugeLinkField>, MIO);
 
 /******************************************************************************
  *                 TLoadField implementation                             *

--- a/Hadrons/Modules/MIO/SaveField.cpp
+++ b/Hadrons/Modules/MIO/SaveField.cpp
@@ -33,3 +33,4 @@ template class Grid::Hadrons::MIO::TSaveField<FIMPL::PropagatorField>;
 #ifdef GRID_DEFAULT_PRECISION_DOUBLE
 template class Grid::Hadrons::MIO::TSaveField<FIMPL::PropagatorField, FIMPLF::PropagatorField>;
 #endif
+template class Grid::Hadrons::MIO::TSaveField<GIMPL::GaugeLinkField>;

--- a/Hadrons/Modules/MIO/SaveField.hpp
+++ b/Hadrons/Modules/MIO/SaveField.hpp
@@ -80,6 +80,7 @@ MODULE_REGISTER_TMP(SavePropagator, TSaveField<FIMPL::PropagatorField>, MIO);
 #ifdef GRID_DEFAULT_PRECISION_DOUBLE
 MODULE_REGISTER_TMP(SavePropagatorIo32, ARG(TSaveField<FIMPL::PropagatorField, FIMPLF::PropagatorField>), MIO);
 #endif
+MODULE_REGISTER_TMP(SaveColourMatrixField, TSaveField<GIMPL::GaugeLinkField>, MIO);
 
 /******************************************************************************
  *                 TSaveField implementation                             *

--- a/Hadrons/Modules/MIO/SaveNersc.cpp
+++ b/Hadrons/Modules/MIO/SaveNersc.cpp
@@ -1,5 +1,5 @@
 /*
- * LoadField.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ * LoadNersc.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
  *
  * Copyright (C) 2015 - 2020
  *
@@ -23,14 +23,10 @@
  */
 
 /*  END LEGAL */
-#include <Hadrons/Modules/MIO/LoadField.hpp>
+#include <Hadrons/Modules/MIO/SaveNersc.hpp>
 
 using namespace Grid;
 using namespace Hadrons;
 using namespace MIO;
 
-template class Grid::Hadrons::MIO::TLoadField<FIMPL::PropagatorField>;
-#ifdef GRID_DEFAULT_PRECISION_DOUBLE
-template class Grid::Hadrons::MIO::TLoadField<FIMPL::PropagatorField, FIMPLF::PropagatorField>;
-#endif
-template class Grid::Hadrons::MIO::TLoadField<GIMPL::GaugeLinkField>;
+template class Grid::Hadrons::MIO::TSaveNersc<GIMPL>;

--- a/Hadrons/Modules/MIO/SaveNersc.hpp
+++ b/Hadrons/Modules/MIO/SaveNersc.hpp
@@ -1,0 +1,169 @@
+/*
+ * SaveNersc.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2020
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+#ifndef Hadrons_MIO_SaveNersc_hpp_
+#define Hadrons_MIO_SaveNersc_hpp_
+
+#include <Hadrons/Global.hpp>
+#include <Hadrons/Module.hpp>
+#include <Hadrons/ModuleFactory.hpp>
+
+BEGIN_HADRONS_NAMESPACE
+
+/******************************************************************************
+ *                       Save a NERSC configuration                           *
+ ******************************************************************************/
+
+// gauge          Name of the gauge field object to write
+// file           Name of the file to write the gauge field to
+// gaugeMetadata  (optional) Name of the file the gauge was loaded from
+//                ... so metadata can be copied
+// comment        (optional) value to write in COMMENT field of gauge-field metadata
+//                e.g. "gauge fixed: alpha=0.05, maxiter=1000000, Omega_tol=1e-12,
+//                      Phi_tol=1e-12, gaugeFix=coulomb, Fourier=true"
+
+BEGIN_MODULE_NAMESPACE(MIO)
+
+class SaveNerscPar: Serializable
+{
+public:
+    GRID_SERIALIZABLE_CLASS_MEMBERS(SaveNerscPar,
+                                    std::string, gauge,
+                                    std::string, file,
+                                    std::string, gaugeMetadata,
+                                    std::string, comment);
+};
+
+template <typename GImpl>
+class TSaveNersc: public Module<SaveNerscPar>
+{
+public:
+    GAUGE_TYPE_ALIASES(GImpl,);
+public:
+    // constructor
+    TSaveNersc(const std::string name);
+    // destructor
+    virtual ~TSaveNersc(void) {};
+    // dependency relation
+    virtual std::vector<std::string> getInput(void);
+    virtual std::vector<std::string> getOutput(void);
+    // setup
+    virtual void setup(void);
+    // execution
+    virtual void execute(void);
+};
+
+MODULE_REGISTER_TMP(SaveNersc,  TSaveNersc<GIMPL>,  MIO);
+
+/******************************************************************************
+*                       TSaveNersc implementation                             *
+******************************************************************************/
+// constructor /////////////////////////////////////////////////////////////////
+template <typename GImpl>
+TSaveNersc<GImpl>::TSaveNersc(const std::string name)
+: Module<SaveNerscPar>(name)
+{}
+
+// dependencies/products ///////////////////////////////////////////////////////
+template <typename GImpl>
+std::vector<std::string> TSaveNersc<GImpl>::getInput(void)
+{
+  return { par().gauge };
+}
+
+template <typename GImpl>
+std::vector<std::string> TSaveNersc<GImpl>::getOutput(void)
+{
+    return {};
+}
+
+// setup ///////////////////////////////////////////////////////////////////////
+template <typename GImpl>
+void TSaveNersc<GImpl>::setup(void)
+{
+}
+
+// Class to write metadata /////////////////////////////////////////////////////
+template<typename GImpl> class CachedGaugeFixedStatistics
+{
+public:
+    GAUGE_TYPE_ALIASES(GImpl,);
+    FieldMetaData fmd;
+
+    CachedGaugeFixedStatistics(std::string metadataFile, GridBase *grid)
+    {
+        LOG(Message) << "Copying NERSC metadata from file '" << metadataFile
+                     << "'" << std::endl;
+        NerscIO::readHeader(metadataFile, grid, fmd);
+    }
+
+    void operator()(GaugeField & data,FieldMetaData &header)
+    {
+        header.link_trace=WilsonLoops<GImpl>::linkTrace(data);
+        header.plaquette =WilsonLoops<GImpl>::avgPlaquette(data);
+        header.hdr_version = fmd.hdr_version;
+        header.storage_format = fmd.storage_format;
+        header.ensemble_id = fmd.ensemble_id;
+        header.ensemble_label = fmd.ensemble_label;
+        header.sequence_number = fmd.sequence_number;
+    }
+};
+
+// execution ///////////////////////////////////////////////////////////////////
+template <typename GImpl>
+void TSaveNersc<GImpl>::execute(void)
+{
+    std::map<std::string,std::string> extraMetadata;
+    if( !par().comment.empty() )
+    {
+        extraMetadata["COMMENT"] = par().comment;
+    }
+
+    std::string   traj = "." + std::to_string(vm().getTrajectory());
+    std::string fileName = par().file + traj;
+    LOG(Message) << "Saving NERSC configuration to file '" << fileName
+                 << "'" << std::endl;
+
+    auto &U = envGet(GaugeField, par().gauge);
+    const bool bCopyMetadata = !par().gaugeMetadata.empty();
+    if( bCopyMetadata )
+    {
+        using CachedStats = CachedGaugeFixedStatistics<GImpl>;
+        std::string metadataFile = par().gaugeMetadata + traj;
+        CachedStats Cache(metadataFile, U.Grid());
+        NerscIO::writeConfiguration<CachedGaugeFixedStatistics<GImpl>>
+                                   (U, fileName, 0, 0, Cache, &extraMetadata);
+    }
+    else
+    {
+        NerscIO::writeConfiguration<GaugeStatistics<GImpl>>(U, fileName, 0, 0, &extraMetadata);
+    }
+}
+
+END_MODULE_NAMESPACE
+
+END_HADRONS_NAMESPACE
+
+#endif // Hadrons_MIO_SaveNersc_hpp_

--- a/Hadrons/Modules/MIO/SaveNersc.hpp
+++ b/Hadrons/Modules/MIO/SaveNersc.hpp
@@ -49,7 +49,7 @@ class SaveNerscPar: Serializable
 public:
     GRID_SERIALIZABLE_CLASS_MEMBERS(SaveNerscPar,
                                     std::string, gauge,
-                                    std::string, file,
+                                    std::string, fileStem,
                                     std::string, ensembleLabel);
 };
 
@@ -106,11 +106,12 @@ void TSaveNersc<GImpl>::setup(void)
 template <typename GImpl>
 void TSaveNersc<GImpl>::execute(void)
 {
-    std::string fileName = par().file + "." + std::to_string(vm().getTrajectory());
+    std::string fileName = par().fileStem + "." + std::to_string(vm().getTrajectory());
     LOG(Message) << "Saving NERSC configuration to file '" << fileName
                  << "'" << std::endl;
 
     auto &U = envGet(GaugeField, par().gauge);
+    makeFileDir(fileName, U.Grid());
     NerscIO::writeConfiguration(U, fileName, par().ensembleLabel);
 }
 


### PR DESCRIPTION
New module: MIO::SaveNersc saves a gauge field (e.g. after gauge fixing). New modules MIO::{Save,Load}ColourMatrixField registered in MIO/{Save,Load}Field can be used to save/load the gauge transformation matrices