### PR TITLE
Feature/WardAxial Save density as well as derivative

### DIFF
--- a/Hadrons/Modules/MContraction/WardIdentity.hpp
+++ b/Hadrons/Modules/MContraction/WardIdentity.hpp
@@ -256,7 +256,7 @@ void TWardIdentity<FImpl>::execute(void)
         // Compute and save temporal component of local-axial current
         // A_0 from eq (37) in https://arxiv.org/pdf/hep-lat/0612005.pdf
         // together with \mathcal{A}_0 allows Z_A to be computed, see eq (38)
-        tmp_current = trace(adj(psi) * (gT * psi));
+        tmp_current = - trace(adj(psi) * (gT * psi));
         SlicedComplex sumPALocal0(nt);
         SliceOut(result.PALocal0, sumPALocal0, tmp_current, false);
 #ifdef  COMPARE_Test_Cayley_mres

--- a/Hadrons/Modules/MContraction/WardIdentity.hpp
+++ b/Hadrons/Modules/MContraction/WardIdentity.hpp
@@ -75,14 +75,14 @@ public:
         GRID_SERIALIZABLE_CLASS_MEMBERS(Result,
                                         double,               mass,
                                         std::vector<Complex>, DmuJmu,  // D_mu trace(Scalar*conserved_vector_mu)
-                                        std::vector<Complex>, DmuPAmu, // D_mu trace(pseudoscalar*conserved_axial_mu)
-                                        std::vector<Complex>, PP,      // Pseudoscalar density
-                                        std::vector<Complex>, PJ5q,    // Midpoint axial current density
-                                        std::vector<Complex>, mres,    // residual mass = <PJ5q> / <PP>
                                         std::vector<Complex>, VDmuJmu, // D_mu trace(local_vector*conserved_vector_mu)
-                                        std::vector<Complex>, DefectPA,// DmuPAmu[t] - 2.*(result.mass*result.PP[t] + result.PJ5q[t])
-                                        std::vector<Complex>, PA0,     //      trace(pseudoscalar*conserved_axial_0)
-                                        std::vector<Complex>, PALocal0);//trace( temporal local axial - pseudoscalar )
+                                        std::vector<Complex>, PJ5q,    // Midpoint axial current density
+                                        std::vector<Complex>, PA0);    //      trace(pseudoscalar*conserved_axial_0)
+                                     // std::vector<Complex>, DmuPAmu, // D_mu trace(pseudoscalar*conserved_axial_mu)
+                                     // std::vector<Complex>, PP,      // Pseudoscalar density
+                                     // std::vector<Complex>, mres,    // residual mass = <PJ5q> / <PP>
+                                     // std::vector<Complex>, DefectPA,// DmuPAmu[t] - 2.*(mass*PP[t] + PJ5q[t])
+                                     // std::vector<Complex>, PALocal0,//trace( temporal local axial - pseudoscalar )
     };
 
 public:
@@ -99,7 +99,7 @@ protected:
     // execution
     virtual void execute(void);
     // Perform Slice Sum and then save delta
-    void SliceOut(std::vector<Complex> &Out, SlicedComplex &Sum, const ComplexField &f, bool bDiff=true) const
+    void SliceOut(std::vector<Complex> &Out, SlicedComplex &Sum, const ComplexField &f, bool bDiff) const
     {
         sliceSum(f, Sum, Tp);
         const auto nt = Sum.size();
@@ -155,13 +155,6 @@ void TWardIdentity<FImpl>::setup(void)
     // These temporaries are always 4d
     envTmpLat(PropagatorField, "tmp");
     envTmpLat(ComplexField, "tmp_current");
-    // For 5d actions, I'll also need the 4d propagator, so we can compute pseudoscalar density
-    if (Ls_ > 1)
-    {
-        envTmpLat(FermionField, "ferm5d", Ls_); // One spin and colour of the 5d propagator
-        envTmpLat(FermionField, "ferm4d"); // One spin and colour of the 4d propagator
-        envTmpLat(PropagatorField, "psi"); // This will hold the 4d version of the 5d propagator
-    }
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -182,14 +175,9 @@ void TWardIdentity<FImpl>::execute(void)
     result.mass = par().mass;
     const int nt { env().getDim(Tp) };
     result.DmuJmu.resize(nt, 0.);
-    result.DmuPAmu.resize(nt, 0.);
-    result.PP.resize(nt, 0.);
-    result.PJ5q.resize(nt, 0.);
-    result.mres.resize(nt, 0.);
     result.VDmuJmu.resize(nt, 0.);
-    result.DefectPA.resize(nt, 0.);
+    result.PJ5q.resize(nt, 0.);
     result.PA0.resize(nt, 0.);
-    result.PALocal0.resize(nt, 0.);
 
     // Compute D_mu V_mu (D here is backward derivative)
     // There is no point performing Dmu on spatial directions, because after the spatial sum, these become zero
@@ -201,10 +189,10 @@ void TWardIdentity<FImpl>::execute(void)
     act.ContractConservedCurrent(prop, prop, tmp, phys_source, Current::Vector, Tdir);
     // Scalar-vector current density
     tmp_current = trace(tmp);
-    SliceOut(result.DmuJmu, sumSV, tmp_current);
+    SliceOut(result.DmuJmu, sumSV, tmp_current, true);
     // Vector-vector current density
     tmp_current = trace(gT*tmp);
-    SliceOut(result.VDmuJmu, sumVV, tmp_current);
+    SliceOut(result.VDmuJmu, sumVV, tmp_current, true);
 //#define COMPARE_Test_Cayley_mres
 #ifdef  COMPARE_Test_Cayley_mres
     // For comparison with Grid Test_Cayley_mres
@@ -227,51 +215,10 @@ void TWardIdentity<FImpl>::execute(void)
         // Save temporal component of pseudoscalar-(partially) conserved axial
         // \mathcal{A}_0 from eq (37) in https://arxiv.org/pdf/hep-lat/0612005.pdf
         SliceOut(result.PA0, sumPA, tmp_current, false);
-        for (size_t t = 0; t < nt; ++t)
-        {
-            result.DmuPAmu[t] = TensorRemove(sumPA[t] - sumPA[(t-1+nt)%nt]);
-        }
         // <P|J5q>
         act.ContractJ5q(prop, tmp_current);
         SlicedComplex sumPJ5q(nt);
         SliceOut(result.PJ5q, sumPJ5q, tmp_current, false);
-        // <P|P>
-        LOG(Message) << "Getting 4d propagator for " << par().prop << std::endl;
-        envGetTmp(FermionField, ferm5d);
-        envGetTmp(FermionField, ferm4d);
-        envGetTmp(PropagatorField, psi);
-        for (int s = 0; s < Ns; ++s)
-        {
-            for (int c = 0; c < Nc; ++c)
-            {
-                PropToFerm<FImpl>(ferm5d,prop,s,c);
-                act.ExportPhysicalFermionSolution(ferm5d,ferm4d);
-                FermToProp<FImpl>(psi,ferm4d,s,c);
-            }
-        }
-        LOG(Message) << "Getting pseudoscalar density" << std::endl;
-        tmp_current = trace(adj(psi) * psi);
-        SlicedComplex sumPP(nt);
-        SliceOut(result.PP, sumPP, tmp_current, false);
-        // Compute and save temporal component of local-axial current
-        // A_0 from eq (37) in https://arxiv.org/pdf/hep-lat/0612005.pdf
-        // together with \mathcal{A}_0 allows Z_A to be computed, see eq (38)
-        tmp_current = - trace(adj(psi) * (gT * psi));
-        SlicedComplex sumPALocal0(nt);
-        SliceOut(result.PALocal0, sumPALocal0, tmp_current, false);
-#ifdef  COMPARE_Test_Cayley_mres
-        LOG(Message) << "Axial Ward Identity by timeslice" << std::endl;
-        LOG(Message) << "Mass=" << result.mass << std::endl;
-#endif
-        for (int t = 0; t < nt; ++t)
-        {
-            result.DefectPA[t] = result.DmuPAmu[t] - 2.*(result.mass*result.PP[t] + result.PJ5q[t]);
-            result.mres[t]     = result.PJ5q[t] / result.PP[t];
-#ifdef  COMPARE_Test_Cayley_mres
-            // This output can be compared with Grid Test_cayley_mres
-            LOG(Message) << " t=" << t << ", DmuPAmu=" << real(result.DmuPAmu[t]) << ", PP=" << real(result.PP[t]) << ", PJ5q=" << real(result.PJ5q[t]) << ", PCAC/AWI defect=" << real(result.DefectPA[t]) << std::endl;
-#endif
-        }
     }
 
     LOG(Message) << "Writing results to " << par().output << "." << std::endl;


### PR DESCRIPTION
It is useful to have the (temporal component of the partially) conserved axial current density as well as the derivative, so this has been added to the output as "PA0".
The output file already contains the pseudoscalar density <PP> so that residual mass can be easily computed.
By analogy, I've also added the (temporal component of the) local axial current density as "PALocal0".
These two values allow Z_A to be determined, see eq (37) and (38) in https://arxiv.org/pdf/hep-lat/0612005.pdf.
Source comments for output fields are inline in the output definition, lines 77-85.
The values of PP and PALocal0 have been checked against the same values computed using the Meson contraction module and they agree.