### PR TITLE
Fix DiskVector bug/crash

### DIFF
--- a/Hadrons/DiskVector.hpp
+++ b/Hadrons/DiskVector.hpp
@@ -461,8 +461,15 @@ void DiskVectorBase<T>::cacheInsert(const unsigned int i, const T &obj) const
     auto &loads    = *loadsPtr_;
 
     evict();
-    index[i] = freeInd.top();
-    freeInd.pop();
+    if (index.find(i) == index.end()) {
+	index[i] = freeInd.top();
+	freeInd.pop();
+    }
+    else {
+	auto pos = std::find(loads.begin(), loads.end(), i);
+	assert(pos != loads.end());
+	loads.erase(pos);
+    }
     cache[index.at(i)] = obj;
     loads.push_back(i);
     modified[index.at(i)] = false;

--- a/tests/Test_diskvector.cpp
+++ b/tests/Test_diskvector.cpp
@@ -96,6 +96,7 @@ int main(int argc, char *argv[])
 
     w[2] = EigenDiskVectorMat<ComplexD>::Random(2000, 2000);
     m    = w[2];
+    w[2] = m;
     w[3] = EigenDiskVectorMat<ComplexD>::Random(2000, 2000);
     w[4] = EigenDiskVectorMat<ComplexD>::Random(2000, 2000);
     w[5] = EigenDiskVectorMat<ComplexD>::Random(2000, 2000);


### PR DESCRIPTION
 This fixes an issue/crash I've run into while using disk vectors. I've put more detail in the commit message, but the summary is that writing to an element already present in the cache can cause issues that later lead to a crash if the cache fills up. You can see this by running Test_diskvector with the modification I've included; with the current develop build that modification causes an out_of_range exception.
 
 I've tried to match the original behavior as closely as possible, but I'd be open to rearranging things a bit if you think it fits better with the rest of the code.