### PR TITLE
Specify the name of each propagator field to unpack…

### DIFF
--- a/Hadrons/Modules/MUtilities/VectorUnpack.hpp
+++ b/Hadrons/Modules/MUtilities/VectorUnpack.hpp
@@ -5,6 +5,7 @@
  *
  * Author: Antonin Portelli <antonin.portelli@me.com>
  * Author: Fionn O hOgain <fionn.o.hogain@ed.ac.uk>
+ * Author: Michael Marshall <michael.marshall@ed.ac.uk>
  *
  * Hadrons is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -43,7 +44,7 @@ class VectorUnpackPar: Serializable
 public:
     GRID_SERIALIZABLE_CLASS_MEMBERS(VectorUnpackPar,
                                     std::string,  input,
-                                    unsigned int, size);
+                                    std::vector<std::string>, fields);
 };
 
 template <typename Field>
@@ -88,14 +89,7 @@ std::vector<std::string> TVectorUnpack<Field>::getInput(void)
 template <typename Field>
 std::vector<std::string> TVectorUnpack<Field>::getOutput(void)
 {
-    std::vector<std::string> out;
-
-    for (unsigned int i = 0; i < par().size; ++i)
-    {
-        out.push_back(getName() + "_" + std::to_string(i));
-    }
-    
-    return out;
+    return par().fields;
 }
 
 // setup ///////////////////////////////////////////////////////////////////////
@@ -106,17 +100,17 @@ void TVectorUnpack<Field>::setup(void)
     unsigned int Ls    = env().getObjectLs(par().input);
     auto         *grid = vec[0].Grid();
 
-    if (vec.size() != par().size)
+    if (vec.size() != par().fields.size())
         {
             HADRONS_ERROR(Size,"Mismatch between vector size ("
                                 + std::to_string(vec.size())
                                 + ") and module parameter size ("
-                                + std::to_string(par().size) + ").");
+                                + std::to_string(par().fields.size()) + ").");
         }
 
-    for (unsigned int i = 0; i < vec.size(); ++i)
+    for (const std::string &ThisName : par().fields)
     {
-        envCreate(Field, getName() + "_" + std::to_string(i), Ls, grid);
+        envCreate(Field, ThisName, Ls, grid);
     }
 }
 
@@ -129,7 +123,7 @@ void TVectorUnpack<Field>::execute(void)
     LOG(Message) << "Unpacking vector '" << par().input << "'" << std::endl;
     for (unsigned int i = 0; i < vec.size(); ++i)
     {
-        auto &veci = envGet(Field, getName() + "_" + std::to_string(i));
+        auto &veci = envGet(Field, par().fields[i]);
 
         veci = vec[i];
     }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,7 +20,7 @@ CLEANFILES = $(EXTRA_PROGRAMS)
 
 tests-local: $(EXTRA_PROGRAMS)
 
-Test_QED_Local_SOURCES=Test_QED_LOCAL.cpp
+Test_QED_Local_SOURCES=Test_QED_Local.cpp
 Test_QED_Local_LDADD=-lHadrons -lGrid
 
 Test_QED_SOURCES=Test_QED.cpp

--- a/tests/Test_distil.cpp
+++ b/tests/Test_distil.cpp
@@ -191,7 +191,7 @@ void test_Perambulators( Application &application, const char * pszSuffix = null
   // Perambulator parameters
   MDistil::Perambulator::Par PerambPar;
   PerambPar.lapevec = "LapEvec";
-  PerambPar.PerambFileName = sModuleName;
+  PerambPar.perambFileName = sModuleName;
   PerambPar.solver = test_Solver( application, pszSuffix );
   PerambPar.DistilParams = "DPar_l";
   PerambPar.noise = "noise";

--- a/tests/Test_hadrons_spectrum.cpp
+++ b/tests/Test_hadrons_spectrum.cpp
@@ -76,6 +76,7 @@ int main(int argc, char *argv[])
     globalPar.database.restoreModules       = false;
     globalPar.database.restoreMemoryProfile = false;
     globalPar.database.makeStatDb           = true;
+    globalPar.database.statDbPeriodMs       = 500;
     application.setPar(globalPar);
     // gauge field
     application.createModule<MGauge::Unit>("gauge");


### PR DESCRIPTION
… instead of the number of fields. This forces the name of each propagator to be specified ... which in practice is likely to be exactly what is required.