### PR TITLE
Stat logger evictable memory fix

### DIFF
--- a/Hadrons/StatLogger.cpp
+++ b/Hadrons/StatLogger.cpp
@@ -196,6 +196,7 @@ void StatLogger::logDeviceMemory(const GridTime::rep time)
     e.totalCurrent          = 0;
     e.envCurrent            = 0;
     e.gridCurrent           = MemoryManager::DeviceBytes;
+    e.evictableCurrent      = MemoryManager::DeviceLRUBytes;
     buf.h2d                 = MemoryManager::HostToDeviceBytes;
     buf.h2dTr               = MemoryManager::HostToDeviceXfer;
     buf.d2h                 = MemoryManager::DeviceToHostBytes;


### PR DESCRIPTION
I noticed the evictable memory output in the database was being filled with uninitialised values.

Here is a fix that gives the correct evictable memory from grid