### PR TITLE
Stat db collision fix

### DIFF
--- a/Hadrons/Application.cpp
+++ b/Hadrons/Application.cpp
@@ -172,7 +172,7 @@ void Application::run(void)
     LOG(Message) << "Attempt(s) for resilient parallel I/O: " 
                  << BinaryIO::latticeWriteMaxRetry << std::endl;
     vm().setRunId(getPar().runId);
-    if (getPar().database.makeStatDb)
+    if (!getPar().database.statDbBase.empty())
     {
         std::string        statDbFilename;
         std::ostringstream oss;
@@ -180,7 +180,7 @@ void Application::run(void)
         auto nowLocal = *std::localtime(&now);
 
         oss << std::put_time(&nowLocal, "%Y%m%d-%H%M%S");
-        statDbFilename = getPar().runId + "-stat-" + oss.str() + ".db";
+        statDbFilename = getPar().database.statDbBase + getPar().runId + "-stat-" + oss.str() + ".db";
         LOG(Message) << "Logging run statistics in '" << statDbFilename << "'" << std::endl;
         if (env().getGrid()->IsBoss())
         {
@@ -213,7 +213,7 @@ void Application::run(void)
         vm().dumpModuleGraph(getPar().graphFile);
     }
     configLoop();
-    if (getPar().database.makeStatDb and env().getGrid()->IsBoss())
+    if (!getPar().database.statDbBase.empty() and env().getGrid()->IsBoss())
     {
         statLogger.stop();
     }

--- a/Hadrons/Application.hpp
+++ b/Hadrons/Application.hpp
@@ -58,10 +58,10 @@ public:
                                         bool,        restoreModules,
                                         bool,        restoreMemoryProfile,
                                         bool,        restoreSchedule,
-                                        bool,        makeStatDb);
+                                        std::string, statDbBase);
         DatabasePar(void): 
         restoreModules{false}, restoreMemoryProfile{false},
-        restoreSchedule{false}, makeStatDb{false} {}
+        restoreSchedule{false}, statDbBase{""} {}
     };
 
     struct GlobalPar: Serializable


### PR DESCRIPTION
Here is my suggestion for the stat db collision issue.
It allows the user to specify the base of the stat db filename and the rest of the filename is the same as before.

I've removed the `makeStatDb` bool and replaced it with a check that the new `statDbBase` string is empty. Therefore the user would have to specify something like `<statDbBase>./</statDbBase>` to get the current behaviour back.

Since the default string is empty, for current user code this change will ignore the existing `makeStatDb` and default `statDbBase` to empty. So by default they will get no stat logging.

Perhaps we want to leave the `makeStatDb` bool in as well so the user can leave `statDbBase` blank or not specify it to get back the current behaviour and current code doesn't have to be updated.

I am open to suggestions.