### PR TITLE
Replaced Wilson Clover action by Compact Wilson Clover

### DIFF
--- a/Hadrons/Modules/MAction/WilsonClover.hpp
+++ b/Hadrons/Modules/MAction/WilsonClover.hpp
@@ -43,11 +43,15 @@ BEGIN_MODULE_NAMESPACE(MAction)
 class WilsonCloverPar: Serializable
 {
 public:
+    WilsonCloverPar(void):
+        cF{1.0} {};
+public:
     GRID_SERIALIZABLE_CLASS_MEMBERS(WilsonCloverPar,
                                     std::string, gauge,
                                     double     , mass,
 				                    double     , csw_r,
 				                    double     , csw_t,
+                                    double     , cF,
 				                    WilsonAnisotropyCoefficients ,clover_anisotropy,
                                     std::string, boundary,
                                     std::string, twist
@@ -138,8 +142,8 @@ void TWilsonClover<FImpl>::setup(void)
     {
         HADRONS_ERROR(Size, "Wrong number of twist");
     }
-    envCreateDerived(FMat, WilsonCloverFermion<FImpl>, getName(), 1, U, grid,
-                     gridRb, par().mass, par().csw_r, par().csw_t, 
+    envCreateDerived(FMat, CompactWilsonCloverFermion<FImpl>, getName(), 1, U, grid,
+                     gridRb, par().mass, par().csw_r, par().csw_t, par().cF,
                      par().clover_anisotropy, implParams); 
 }
 

--- a/Hadrons/Modules/MAction/WilsonClover.hpp
+++ b/Hadrons/Modules/MAction/WilsonClover.hpp
@@ -43,9 +43,6 @@ BEGIN_MODULE_NAMESPACE(MAction)
 class WilsonCloverPar: Serializable
 {
 public:
-    WilsonCloverPar(void):
-        cF{1.0} {};
-public:
     GRID_SERIALIZABLE_CLASS_MEMBERS(WilsonCloverPar,
                                     std::string, gauge,
                                     double     , mass,
@@ -112,10 +109,11 @@ std::vector<std::string> TWilsonClover<FImpl>::getOutput(void)
 template <typename FImpl>
 void TWilsonClover<FImpl>::setup(void)
 {
-    LOG(Message) << "Setting up Wilson clover fermion matrix with m= " << par().mass
+    LOG(Message) << "Setting up Wilson clover fermion matrix with m = " << par().mass
                  << " using gauge field '" << par().gauge << "'" << std::endl;
     LOG(Message) << "Clover term csw_r: " << par().csw_r
-                 << " csw_t: " << par().csw_t
+                 << " csw_t: " << par().csw_t << std::endl;
+    LOG(Message) << "Boundary improvement coefficient cF = " << par().cF
                  << std::endl;
                  
     auto &U      = envGet(GaugeField, par().gauge);


### PR DESCRIPTION
I replaced the `WilsonCloverFermion` action in the `WilsonClover` module by the new and more performant `CompactWilsonCloverFermion`. This change breaks backwards compatibility as the new class requires an additional argument `cF` (the new argument is only relevant for calculations with fixed boundary conditions which are now possible).