### PR TITLE
Typo in Perambulator.hpp fixed which is only relevant for 4D actions.

### DIFF
--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -290,7 +290,7 @@ void TPerambulator<FImpl>::execute(void)
                 {
                     START_P_TIMER("solver");
                     solver(fermion4dtmp, dist_source);
-                    START_P_TIMER("solver");
+                    STOP_P_TIMER("solver");
                 }
                 else
                 {


### PR DESCRIPTION
In first tests of the distillation modules with `WilsonExpClover` quarks @nelsonlachini and I identified this trivial bug which is only triggered for 4d actions.