### PR TITLE
Test/perambulator gpu

### DIFF
--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -188,7 +188,7 @@ void TPerambulator<FImpl>::setup(void)
     envTmp(FermionField,         "fermion3dtmp", 1, grid3d);
     envTmpLat(ColourVectorField, "cv4dtmp");
     envTmp(ColourVectorField,    "cv3dtmp", 1, grid3d);
-    envTmp(ColourVectorField,    "evec3d",  1, grid3d);
+    //envTmp(ColourVectorField,    "evec3d",  1, grid3d);
 
     // No solver needed if an already existing solve is recycled    
     if(perambMode != pMode::inputSolve)
@@ -236,18 +236,14 @@ void TPerambulator<FImpl>::execute(void)
     envGetTmp(FermionField,      fermion3dtmp);
     envGetTmp(ColourVectorField, cv4dtmp);
     envGetTmp(ColourVectorField, cv3dtmp);
-    envGetTmp(ColourVectorField, evec3d);
+    //envGetTmp(ColourVectorField, evec3d);
     GridCartesian * grid4d = envGetGrid(FermionField);
     GridCartesian * grid3d = envGetSliceGrid(FermionField,grid4d->Nd() -1);
     const int Ntlocal{grid4d->LocalDimensions()[3]};
     const int Ntfirst{grid4d->LocalStarts()[3]};
 
-    //typedef decltype(coalescedRead(evec3d)) CVFtype;
-    //typedef(typeid(evec3d)) CVFtype;
-
-    //Grid::Vector<ColourVectorField> evec_test(Ntlocal * nVec, grid3d);
-    std::vector<ColourVectorField> evec_test(Ntlocal * nVec, evec3d.Grid());
-    //Grid::Vector<CVFtype> evec_test(Ntlocal * nVec, grid3d);
+    ColourVectorField evec3d(grid3d);
+    std::vector<ColourVectorField> evec_test(Ntlocal * nVec, evec3d.getGrid());
     for (int t = Ntfirst; t < Ntfirst + Ntlocal; t++)
     {
         for (int ivec = 0; ivec < nVec; ivec++)
@@ -255,7 +251,6 @@ void TPerambulator<FImpl>::execute(void)
             int jvec= ivec + nVec * t;
             ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Ntfirst,Tdir);
             evec_test[jvec] = evec3d;
-            //coalescedWrite(evec_test[jvec], evec3d);
         }
     }
 
@@ -356,7 +351,6 @@ void TPerambulator<FImpl>::execute(void)
                     {
                         int jvec= ivec + nVec * t;
                         evec3d = evec_test[jvec];
-                        //coalescedWrite(evec3d, evec_test[jvec]);
                         //ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Ntfirst,Tdir);
                         pokeSpin(perambulator.tensor(t, ivec, dk, inoise,idt,ds),static_cast<Complex>(innerProduct(evec3d, cv3dtmp)),is);
                     }

--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -242,14 +242,18 @@ void TPerambulator<FImpl>::execute(void)
     const int Ntlocal{grid4d->LocalDimensions()[3]};
     const int Ntfirst{grid4d->LocalStarts()[3]};
 
-    Grid::Vector<ColourVectorField> evec_test(Ntlocal * nVec, grid3d);
+    typedef decltype(coalescedRead(evec3d)) CVFtype;
+
+    //Grid::Vector<ColourVectorField> evec_test(Ntlocal * nVec, grid3d);
+    Grid::Vector<CVFtype> evec_test(Ntlocal * nVec, grid3d);
     for (int t = Ntfirst; t < Ntfirst + Ntlocal; t++)
     {
         for (int ivec = 0; ivec < nVec; ivec++)
         {
             int jvec= ivec + nVec * t;
             ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Ntfirst,Tdir);
-            evec_test[jvec] = evec3d;
+            //evec_test[jvec] = evec3d;
+            coalescedWrite(evec_test[jvec], evec3d);
         }
     }
 
@@ -349,7 +353,8 @@ void TPerambulator<FImpl>::execute(void)
                     for (int ivec = 0; ivec < nVec; ivec++)
                     {
                         int jvec= ivec + nVec * t;
-                        evec3d = evec_test[jvec];
+                        //evec3d = evec_test[jvec];
+                        coalescedWrite(evec3d, evec_test[jvec]);
                         //ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Ntfirst,Tdir);
                         pokeSpin(perambulator.tensor(t, ivec, dk, inoise,idt,ds),static_cast<Complex>(innerProduct(evec3d, cv3dtmp)),is);
                     }

--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -242,6 +242,18 @@ void TPerambulator<FImpl>::execute(void)
     const int Ntlocal{grid4d->LocalDimensions()[3]};
     const int Ntfirst{grid4d->LocalStarts()[3]};
 
+    Grid::Vector<ColourVectorField> evec_test(Ntlocal * nVec, grid3d);
+    for (int t = Ntfirst; t < Ntfirst + Ntlocal; t++)
+    {
+        for (int ivec = 0; ivec < nVec; ivec++)
+        {
+            int jvec= ivec + nVec * t;
+            ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Ntfirst,Tdir);
+            evec_test[jvec] = evec3d;
+        }
+    }
+
+
     std::string sourceT = par().timeSources;
     int nSourceT;
     std::vector<int> invT;
@@ -336,7 +348,9 @@ void TPerambulator<FImpl>::execute(void)
                     ExtractSliceLocal(cv3dtmp,cv4dtmp,0,t-Ntfirst,Tdir); 
                     for (int ivec = 0; ivec < nVec; ivec++)
                     {
-                        ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Ntfirst,Tdir);
+                        int jvec= ivec + nVec * t;
+                        evec3d = evec_test[jvec];
+                        //ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Ntfirst,Tdir);
                         pokeSpin(perambulator.tensor(t, ivec, dk, inoise,idt,ds),static_cast<Complex>(innerProduct(evec3d, cv3dtmp)),is);
                     }
                 }

--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -244,7 +244,6 @@ void TPerambulator<FImpl>::execute(void)
     const int Ntlocal{grid4d->LocalDimensions()[3]};
     const int Ntfirst{grid4d->LocalStarts()[3]};
 
-    //std::vector<ColourVectorField> evec_test(Ntlocal * nVec, evec3d.getGrid());
     envGetTmp(std::vector<ColourVectorField>, evec3d_tmp);
     for (int t = Ntfirst; t < Ntfirst + Ntlocal; t++)
     {
@@ -353,7 +352,6 @@ void TPerambulator<FImpl>::execute(void)
                     {
                         int jvec= ivec + nVec * (t-Ntfirst);
                         evec3d = evec3d_tmp[jvec];
-                        //ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Ntfirst,Tdir);
                         pokeSpin(perambulator.tensor(t, ivec, dk, inoise,idt,ds),static_cast<Complex>(innerProduct(evec3d, cv3dtmp)),is);
                     }
                 }

--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -242,18 +242,20 @@ void TPerambulator<FImpl>::execute(void)
     const int Ntlocal{grid4d->LocalDimensions()[3]};
     const int Ntfirst{grid4d->LocalStarts()[3]};
 
-    typedef decltype(coalescedRead(evec3d)) CVFtype;
+    //typedef decltype(coalescedRead(evec3d)) CVFtype;
+    //typedef(typeid(evec3d)) CVFtype;
 
     //Grid::Vector<ColourVectorField> evec_test(Ntlocal * nVec, grid3d);
-    Grid::Vector<CVFtype> evec_test(Ntlocal * nVec, grid3d);
+    std::vector<ColourVectorField> evec_test(Ntlocal * nVec, evec3d.Grid());
+    //Grid::Vector<CVFtype> evec_test(Ntlocal * nVec, grid3d);
     for (int t = Ntfirst; t < Ntfirst + Ntlocal; t++)
     {
         for (int ivec = 0; ivec < nVec; ivec++)
         {
             int jvec= ivec + nVec * t;
             ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Ntfirst,Tdir);
-            //evec_test[jvec] = evec3d;
-            coalescedWrite(evec_test[jvec], evec3d);
+            evec_test[jvec] = evec3d;
+            //coalescedWrite(evec_test[jvec], evec3d);
         }
     }
 
@@ -353,8 +355,8 @@ void TPerambulator<FImpl>::execute(void)
                     for (int ivec = 0; ivec < nVec; ivec++)
                     {
                         int jvec= ivec + nVec * t;
-                        //evec3d = evec_test[jvec];
-                        coalescedWrite(evec3d, evec_test[jvec]);
+                        evec3d = evec_test[jvec];
+                        //coalescedWrite(evec3d, evec_test[jvec]);
                         //ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Ntfirst,Tdir);
                         pokeSpin(perambulator.tensor(t, ivec, dk, inoise,idt,ds),static_cast<Complex>(innerProduct(evec3d, cv3dtmp)),is);
                     }


### PR DESCRIPTION
Speed-up of the perambulator code, which is particularly drastic for setups with short solve times and many eigenvectors. The dominating cost in that case happens in ExtractSliceLocal (of the 3D eigenvectors) deeply nested inside the loops. 

The solution of this pull request is to copy the data into an std::vector object before the actual code starts. At the expense of this extra memory this leads to a substantial speed-up (factor 5 for a particular setup that Fabian Joswig was testing).

The code is tested and compiles, runs, and produces bit-identical results with the old one on GPU and CPU. Fabian sees the factor 5 speed-up when running on Tursa.