### PR TITLE
allow FundtoHirep to compile and link; fix #85

### DIFF
--- a/Hadrons/Module.hpp
+++ b/Hadrons/Module.hpp
@@ -130,6 +130,15 @@ envCreate(type, name, Ls, envGetGrid(type, Ls))
 #define envCreateLat(...)\
 HADRONS_MACRO_REDIRECT_23(__VA_ARGS__, envCreateLat5, envCreateLat4)(__VA_ARGS__)
 
+#define envCreateLat4NS(type, name)\
+envCreate(typename type, name, 1, envGetGrid(type))
+
+#define envCreateLat5NS(type, name, Ls)\
+envCreate(typename type, name, Ls, envGetGrid(type, Ls))
+
+#define envCreateLatNS(...)\
+HADRONS_MACRO_REDIRECT_23(__VA_ARGS__, envCreateLat5NS, envCreateLat4NS)(__VA_ARGS__)
+
 #define envCache(type, name, Ls, ...)\
 this->env().template createObject<type>(name, Environment::Storage::cache, Ls, __VA_ARGS__)
 

--- a/Hadrons/Module.hpp
+++ b/Hadrons/Module.hpp
@@ -130,15 +130,6 @@ envCreate(type, name, Ls, envGetGrid(type, Ls))
 #define envCreateLat(...)\
 HADRONS_MACRO_REDIRECT_23(__VA_ARGS__, envCreateLat5, envCreateLat4)(__VA_ARGS__)
 
-#define envCreateLat4NS(type, name)\
-envCreate(typename type, name, 1, envGetGrid(type))
-
-#define envCreateLat5NS(type, name, Ls)\
-envCreate(typename type, name, Ls, envGetGrid(type, Ls))
-
-#define envCreateLatNS(...)\
-HADRONS_MACRO_REDIRECT_23(__VA_ARGS__, envCreateLat5NS, envCreateLat4NS)(__VA_ARGS__)
-
 #define envCache(type, name, Ls, ...)\
 this->env().template createObject<type>(name, Environment::Storage::cache, Ls, __VA_ARGS__)
 

--- a/Hadrons/Modules/MGauge/FundtoHirep.cpp
+++ b/Hadrons/Modules/MGauge/FundtoHirep.cpp
@@ -30,6 +30,6 @@ using namespace Grid;
 using namespace Hadrons;
 using namespace MGauge;
 
-template class TFundtoHirep<AdjointRepresentation>;
-template class TFundtoHirep<TwoIndexSymmetricRepresentation>;
-template class TFundtoHirep<TwoIndexAntiSymmetricRepresentation>;
+template class MGauge::TFundtoHirep<AdjointRepresentation>;
+template class MGauge::TFundtoHirep<TwoIndexSymmetricRepresentation>;
+template class MGauge::TFundtoHirep<TwoIndexAntiSymmetricRepresentation>;

--- a/Hadrons/Modules/MGauge/FundtoHirep.cpp
+++ b/Hadrons/Modules/MGauge/FundtoHirep.cpp
@@ -30,46 +30,6 @@ using namespace Grid;
 using namespace Hadrons;
 using namespace MGauge;
 
-// constructor /////////////////////////////////////////////////////////////////
-template <class Rep>
-TFundtoHirep<Rep>::TFundtoHirep(const std::string name)
-: Module<FundtoHirepPar>(name)
-{}
-
-// dependencies/products ///////////////////////////////////////////////////////
-template <class Rep>
-std::vector<std::string> TFundtoHirep<Rep>::getInput(void)
-{
-    std::vector<std::string> in = {par().gaugeconf};
-
-    return in;
-}
-
-template <class Rep>
-std::vector<std::string> TFundtoHirep<Rep>::getOutput(void)
-{
-    std::vector<std::string> out = {getName()};
-
-    return out;
-}
-
-// setup ///////////////////////////////////////////////////////////////////////
-template <typename Rep>
-void TFundtoHirep<Rep>::setup(void)
-{
-    envCreateLat(Rep::LatticeField, getName());
-}
-
-// execution ///////////////////////////////////////////////////////////////////
-template <class Rep>
-void TFundtoHirep<Rep>::execute(void)
-{
-    LOG(Message) << "Transforming Representation" << std::endl;
-
-    auto &U    = envGet(LatticeGaugeField, par().gaugeconf);
-    auto &URep = envGet(Rep::LatticeField, getName());
-
-    Rep TargetRepresentation(U._grid);
-    TargetRepresentation.update_representation(U);
-    URep = TargetRepresentation.U;
-}
+template class TFundtoHirep<AdjointRepresentation>;
+template class TFundtoHirep<TwoIndexSymmetricRepresentation>;
+template class TFundtoHirep<TwoIndexAntiSymmetricRepresentation>;

--- a/Hadrons/Modules/MGauge/FundtoHirep.hpp
+++ b/Hadrons/Modules/MGauge/FundtoHirep.hpp
@@ -63,9 +63,54 @@ public:
     void execute(void);
 };
 
-//MODULE_REGISTER_TMP(FundtoAdjoint,   TFundtoHirep<AdjointRepresentation>, MGauge);
-//MODULE_REGISTER_TMP(FundtoTwoIndexSym, TFundtoHirep<TwoIndexSymmetricRepresentation>, MGauge);
-//MODULE_REGISTER_TMP(FundtoTwoIndexAsym, TFundtoHirep<TwoIndexAntiSymmetricRepresentation>, MGauge);
+MODULE_REGISTER_TMP(FundtoAdjoint,   TFundtoHirep<AdjointRepresentation>, MGauge);
+MODULE_REGISTER_TMP(FundtoTwoIndexSym, TFundtoHirep<TwoIndexSymmetricRepresentation>, MGauge);
+MODULE_REGISTER_TMP(FundtoTwoIndexAsym, TFundtoHirep<TwoIndexAntiSymmetricRepresentation>, MGauge);
+
+// constructor /////////////////////////////////////////////////////////////////
+template <class Rep>
+TFundtoHirep<Rep>::TFundtoHirep(const std::string name)
+: Module<FundtoHirepPar>(name)
+{}
+
+// dependencies/products ///////////////////////////////////////////////////////
+template <class Rep>
+std::vector<std::string> TFundtoHirep<Rep>::getInput(void)
+{
+    std::vector<std::string> in = {par().gaugeconf};
+
+    return in;
+}
+
+template <class Rep>
+std::vector<std::string> TFundtoHirep<Rep>::getOutput(void)
+{
+    std::vector<std::string> out = {getName()};
+
+    return out;
+}
+
+// setup ///////////////////////////////////////////////////////////////////////
+template <typename Rep>
+void TFundtoHirep<Rep>::setup(void)
+{
+    envCreateLatNS(Rep::LatticeField, getName());
+}
+
+// execution ///////////////////////////////////////////////////////////////////
+template <class Rep>
+void TFundtoHirep<Rep>::execute(void)
+{
+    LOG(Message) << "Transforming Representation" << std::endl;
+
+    auto &U    = envGet(LatticeGaugeField, par().gaugeconf);
+    auto &URep = envGet(typename Rep::LatticeField, getName());
+
+    Rep TargetRepresentation(U.Grid());
+    TargetRepresentation.update_representation(U);
+    URep = TargetRepresentation.U;
+}
+
 
 END_MODULE_NAMESPACE
 

--- a/Hadrons/Modules/MGauge/FundtoHirep.hpp
+++ b/Hadrons/Modules/MGauge/FundtoHirep.hpp
@@ -94,7 +94,8 @@ std::vector<std::string> TFundtoHirep<Rep>::getOutput(void)
 template <typename Rep>
 void TFundtoHirep<Rep>::setup(void)
 {
-    envCreateLatNS(Rep::LatticeField, getName());
+    typedef typename Rep::LatticeField RepLatticeField;
+    envCreateLat(RepLatticeField, getName());
 }
 
 // execution ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
For a full blow-by-blow of the issue, its debugging, and the thinking behind the solution, see #85, which this PR resolves.

Summary of changes:
* move definition of `TFundtoHirep` methods into `FundtoHirep.hpp` from `FundtoHirep.cpp`
* instantiate the three `TFundtoHirep` specialisations in `FundtoHirep.cpp`
* change `U._grid` to `U.Grid()` following changes in Grid
* prefix references to `Rep::LatticeField` with `typename` to placate compiler
* add new macros to allow the last point to be done in `envCreateLat`, which adds `typename` to one but not both arguments