### PR TITLE
Feature/batch perambulator

### DIFF
--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -194,8 +194,6 @@ void TPerambulator<FImpl>::setup(void)
         envGetGrid(FermionField));
     }
 
-    envTmpLat(FermionField,      "dist_source");
-    envTmpLat(FermionField,      "fermion4dtmp");
     envTmp(FermionField,         "fermion3dtmp", 1, grid3d);
     envTmpLat(ColourVectorField, "cv4dtmp");
     envTmp(ColourVectorField,    "cv3dtmp", 1, grid3d);
@@ -207,8 +205,6 @@ void TPerambulator<FImpl>::setup(void)
     if(perambMode != pMode::inputSolve)
     {
         Ls_ = env().getObjectLs(par().solver);
-        envTmpLat(FermionField, "v5dtmp", Ls_);
-        envTmpLat(FermionField, "v5dtmp_sol", Ls_);
         envTmp(std::vector<FermionField>, "v5dtmp_vec", Ls_, sourceBatchSize, envGetGrid(FermionField, Ls_));
         envTmp(std::vector<FermionField>, "v5dtmp_sol_vec", Ls_,  sourceBatchSize, envGetGrid(FermionField, Ls_));
     }
@@ -246,8 +242,6 @@ void TPerambulator<FImpl>::execute(void)
     pMode perambMode{par().perambMode};
     LOG(Message)<< "Mode " << perambMode << std::endl;
 
-    envGetTmp(FermionField,      dist_source);
-    envGetTmp(FermionField,      fermion4dtmp);
     envGetTmp(FermionField,      fermion3dtmp);
     envGetTmp(ColourVectorField, cv4dtmp);
     envGetTmp(ColourVectorField, cv3dtmp);
@@ -327,8 +321,7 @@ void TPerambulator<FImpl>::execute(void)
             {
                 int inoise = (iSource + batchBegin) / nD; // for (int inoise = 0; inoise < nNoise; inoise++)
                 int d =      (iSource + batchBegin) % nD; // for (int d = 0; d < nD; d++)
-                dist_source = dilNoise.makeSource(d,inoise);
-                dist_source_vec[iSource] = dist_source; 
+                dist_source_vec[iSource] = dilNoise.makeSource(d,inoise);
                 fermion4dtmp_vec[iSource]=0;
             }
             // Solve on batched vector
@@ -406,6 +399,10 @@ void TPerambulator<FImpl>::execute(void)
             index = dilNoise.dilutionCoordinates(d);
             dt = index[DistillationNoise<FImpl>::Index::t];
             dk = index[DistillationNoise<FImpl>::Index::l];
+            if(dk>=nDL_reduced)
+            {
+                continue;
+            }
             ds = index[DistillationNoise<FImpl>::Index::s];
             std::vector<int>::iterator it = std::find(std::begin(invT), std::end(invT), dt);
             // Skip dilution indices which are not in invT
@@ -432,103 +429,7 @@ void TPerambulator<FImpl>::execute(void)
             STOP_P_TIMER("perambulator computation");
         } 
     } //end of batch
-    /*
-    for (int inoise = 0; inoise < nNoise; inoise++)
-    {
-        for (int d = 0; d < nD; d++)
-        {
-            index = dilNoise.dilutionCoordinates(d);
-            dt = index[DistillationNoise<FImpl>::Index::t];
-            dk = index[DistillationNoise<FImpl>::Index::l];
-            // Skip laplacian dilution indices which are larger than (reduced) number of eigenvectors used for the perambulator 
-            if(dk>=nDL_reduced)
-            {
-                continue;
-            }
-            ds = index[DistillationNoise<FImpl>::Index::s];
-            std::vector<int>::iterator it = std::find(std::begin(invT), std::end(invT), dt);
-            // Skip dilution indices which are not in invT
-            if(it == std::end(invT))
-            {
-                continue;
-            }
-            idt=it - std::begin(invT);
-            if(perambMode == pMode::inputSolve)
-            {
-                START_P_TIMER("input solve");
-                auto &solveIn = envGet(std::vector<FermionField>, par().fullSolve);
-                // Index of the solve just has the reduced time dimension & uses nDL from solveIn
-                dIndexSolve = ds + nDS * dk + nDL * nDS * idt;
-                fermion4dtmp = solveIn[inoise+nNoise*dIndexSolve];
-                STOP_P_TIMER("input solve");
-                LOG(Message) << "re-using source vector: noise " << inoise << " dilution (d_t,d_k,d_alpha) : (" << dt << ","<< dk << "," << ds << ")" << std::endl;
-            } 
-            else 
-            {   
-                dist_source = dilNoise.makeSource(d,inoise);
-                fermion4dtmp=0;
-                auto &solver=envGet(Solver, par().solver);
-                auto &mat = solver.getFMat();
-                if (Ls_ == 1)
-                {
-                    START_P_TIMER("solver");
-                    solver(fermion4dtmp, dist_source);
-                    STOP_P_TIMER("solver");
-                }
-                else
-                {
-                    START_P_TIMER("solver handling");
-                    envGetTmp(FermionField,      v5dtmp);
-                    envGetTmp(FermionField,      v5dtmp_sol);
-                    mat.ImportPhysicalFermionSource(dist_source, v5dtmp);
-                    STOP_P_TIMER("solver handling");
-                    START_P_TIMER("solver");
-                    solver(v5dtmp_sol, v5dtmp);
-                    STOP_P_TIMER("solver");
-                    START_P_TIMER("solver handling");
-                    mat.ExportPhysicalFermionSolution(v5dtmp_sol, fermion4dtmp);
-                    STOP_P_TIMER("solver handling");
-                }
-                if(perambMode == pMode::outputSolve)
-                {
-                    // Index of the solve just has the reduced time dimension 
-                    START_P_TIMER("output solve");
-                    dIndexSolve = ds + nDS * dk + nDL * nDS * idt;
-                    auto &solveOut = envGet(std::vector<FermionField>, getName()+"_full_solve");
-                    solveOut[inoise+nNoise*dIndexSolve] = fermion4dtmp;
-                    STOP_P_TIMER("output solve");
-                }
-                if(perambMode == pMode::saveSolve)
-                {
-                    // Index of the solve just has the reduced time dimension
-                    START_P_TIMER("save solve");
-                    dIndexSolve = dilNoise.dilutionIndex(dt,dk,ds);
-                    std::string sFileName(par().fullSolveFileName);
-                    sFileName.append("_noise");
-                    sFileName.append(std::to_string(inoise));
-                    DistillationVectorsIo::writeComponent(sFileName, fermion4dtmp, "fullSolve", nNoise, nDL, nDS, nDT, invT, inoise+nNoise*dIndexSolve, vm().getTrajectory());
-                    STOP_P_TIMER("save solve");
-                }
-            }
-            START_P_TIMER("perambulator computation");
-            for (int is = 0; is < Ns; is++)
-            {
-                cv4dtmp = peekSpin(fermion4dtmp,is);
-                for (int t = Ntfirst; t < Ntfirst + Ntlocal; t++)
-                {
-                    ExtractSliceLocal(cv3dtmp,cv4dtmp,0,t-Ntfirst,Tdir); 
-                    for (int ivec = 0; ivec < nVec; ivec++)
-                    {
-                        int jvec= ivec + nVec * (t-Ntfirst);
-                        evec3d = evec3d_tmp[jvec];
-                        pokeSpin(perambulator.tensor(t, ivec, dk, inoise,idt,ds),static_cast<Complex>(innerProduct(evec3d, cv3dtmp)),is);
-                    }
-                }
-            }
-            STOP_P_TIMER("perambulator computation");
-        }
-    }
-    */
+
     // Now share my timeslice data with other members of the grid
     const int NumSlices{grid4d->_processors[Tdir] / grid3d->_processors[Tdir]};
     if (NumSlices > 1)

--- a/Hadrons/Modules/MIO/LoadInterlacedDistillationNoise.hpp
+++ b/Hadrons/Modules/MIO/LoadInterlacedDistillationNoise.hpp
@@ -38,8 +38,8 @@ public:
     virtual ~TLoadInterlacedDistillationNoise(void) {};
     // dependency relation
     virtual std::vector<std::string> getInput(void);
-    virtual std::vector<std::string> getReference(void);
     virtual std::vector<std::string> getOutput(void);
+    virtual DependencyMap getObjectDependencies(void);
     // setup
     virtual void setup(void);
     // execution
@@ -67,11 +67,13 @@ std::vector<std::string> TLoadInterlacedDistillationNoise<FImpl>::getInput(void)
 }
 
 template <typename FImpl>
-std::vector<std::string> TLoadInterlacedDistillationNoise<FImpl>::getReference(void)
+DependencyMap TLoadInterlacedDistillationNoise<FImpl>::getObjectDependencies(void)
 {
-    std::vector<std::string> ref = {par().lapEigenPack};
+    DependencyMap dep;
 
-    return ref;
+    dep.insert({par().lapEigenPack, getName()});
+
+    return dep;
 }
 
 template <typename FImpl>

--- a/Hadrons/Modules/MNoise/ExactDistillation.hpp
+++ b/Hadrons/Modules/MNoise/ExactDistillation.hpp
@@ -32,8 +32,8 @@ public:
     virtual ~TExactDistillation(void) {};
     // dependency relation
     virtual std::vector<std::string> getInput(void);
-    virtual std::vector<std::string> getReference(void);
     virtual std::vector<std::string> getOutput(void);
+    virtual DependencyMap getObjectDependencies(void);
     // setup
     virtual void setup(void);
     // execution
@@ -56,17 +56,19 @@ TExactDistillation<FImpl>::TExactDistillation(const std::string name)
 template <typename FImpl>
 std::vector<std::string> TExactDistillation<FImpl>::getInput(void)
 {
-    std::vector<std::string> in = {};
+    std::vector<std::string> in = {par().lapEigenPack};
     
     return in;
 }
 
 template <typename FImpl>
-std::vector<std::string> TExactDistillation<FImpl>::getReference(void)
+DependencyMap TExactDistillation<FImpl>::getObjectDependencies(void)
 {
-    std::vector<std::string> ref = {par().lapEigenPack};
+    DependencyMap dep;
 
-    return ref;
+    dep.insert({par().lapEigenPack, getName()});
+
+    return dep;
 }
 
 template <typename FImpl>

--- a/Hadrons/Modules/MNoise/InterlacedDistillation.hpp
+++ b/Hadrons/Modules/MNoise/InterlacedDistillation.hpp
@@ -37,8 +37,8 @@ public:
     virtual ~TInterlacedDistillation(void) {};
     // dependency relation
     virtual std::vector<std::string> getInput(void);
-    virtual std::vector<std::string> getReference(void);
     virtual std::vector<std::string> getOutput(void);
+    virtual DependencyMap getObjectDependencies(void);
     // setup
     virtual void setup(void);
     // execution
@@ -61,17 +61,19 @@ TInterlacedDistillation<FImpl>::TInterlacedDistillation(const std::string name)
 template <typename FImpl>
 std::vector<std::string> TInterlacedDistillation<FImpl>::getInput(void)
 {
-    std::vector<std::string> in = {};
+    std::vector<std::string> in = {par().lapEigenPack};
     
     return in;
 }
 
 template <typename FImpl>
-std::vector<std::string> TInterlacedDistillation<FImpl>::getReference(void)
+DependencyMap TInterlacedDistillation<FImpl>::getObjectDependencies(void)
 {
-    std::vector<std::string> ref = {par().lapEigenPack};
+    DependencyMap dep;
 
-    return ref;
+    dep.insert({par().lapEigenPack, getName()});
+
+    return dep;
 }
 
 template <typename FImpl>


### PR DESCRIPTION
Two parts of this pull request:
1) getReference -> getObjectDependencies: This fixes the currently broken distillation Noise code, which is not correctly handled by the scheduler
2) re-organisation of the perambulator module to batch sources for batch deflation. 

Code is tested to produce the same results (up to solver precision) on my laptop. It also compiles on Tursa. Nelson is testing the batch-deflation speed-up and correctness on Tursa currently.