### PR TITLE
Lower meson field memory footprint

### DIFF
--- a/Hadrons/DistilMatrix.hpp
+++ b/Hadrons/DistilMatrix.hpp
@@ -945,7 +945,7 @@ void DmfComputation<FImpl,T,Tio>
                     uint right_block_size = (Side::right==relative_side) ? rel_block_size : anchor_block_size;
                     DistilMatrixSetIo<Tio> block(bBuf.data(), nExtStrLocal , nt_, left_block_size, right_block_size);
 
-                    LOG(Message) << "Distil matrix block" 
+                    LOG(Message) << "Distil matrix block " 
                     << jAnchor/blockSize_ + nblockRel*iRel/blockSize_ + 1 
                     << "/" << nblockRel*nblockAnchor << " [" << iRel << " .. " 
                     << iRel+rel_block_size-1 << ", " << jAnchor << " .. " << jAnchor+anchor_block_size-1 << "] : [relative, anchor]" 

--- a/Hadrons/DistilMatrix.hpp
+++ b/Hadrons/DistilMatrix.hpp
@@ -981,9 +981,9 @@ void DmfComputation<FImpl,T,Tio>
     for (unsigned int ibatchL=0 ; ibatchL<time_dil_source.at(Side::left).size()/dvBatchSize_ ; ibatchL++)   //loop over left dv batches
     {
         std::vector<unsigned int> batch_dtL = fetchDvBatchIdxs(ibatchL,time_dil_source.at(Side::left));
-        START_TIMER("distil vectors");
+        //START_TIMER("distil vectors");
         //makeDvLapSpinBatch(dv, n_idx, epack, Side::left, batch_dtL, peramb);
-        STOP_TIMER("distil vectors");
+        //STOP_TIMER("distil vectors");
         for (unsigned int idtL=0 ; idtL<batch_dtL.size() ; idtL++)
         {
             unsigned int dtL = batch_dtL[idtL];

--- a/Hadrons/DistilMatrix.hpp
+++ b/Hadrons/DistilMatrix.hpp
@@ -1060,10 +1060,10 @@ void DmfComputation<FImpl,T,Tio>
                     unsigned int right_block_size = (Side::right==relative_side) ? rel_block_size : anchor_block_size;
                     DistilMatrixSetIo<Tio> block(bBuf.data(), nExtStrLocal , nt_, left_block_size, right_block_size);
 
-                    LOG(Message) << "Distil matrix block (relative,anchor)" 
+                    LOG(Message) << "Distil matrix block" 
                     << jAnchor/blockSize_ + nblockRel*iRel/blockSize_ + 1 
                     << "/" << nblockRel*nblockAnchor << " [" << iRel << " .. " 
-                    << iRel+rel_block_size-1 << ", " << jAnchor << " .. " << jAnchor+anchor_block_size-1 << "]" 
+                    << iRel+rel_block_size-1 << ", " << jAnchor << " .. " << jAnchor+anchor_block_size-1 << "] : [relative, anchor]" 
                     << std::endl;
 
                     // loop over cache blocks within the current block
@@ -1072,7 +1072,8 @@ void DmfComputation<FImpl,T,Tio>
                     // jAnchor and jjAnchor needs to be associated with anchored_side: can be either left or right!
                     {
                         //fine here, but need to make sure remaining code treats jAnchor,jjAnchor as the anchored side (not right side necessarily)
-                        unsigned int dv_idx_anchoredOffset = Tanchored*dilSizeLS_.at(anchored_side) + jAnchor+jjAnchor; 
+                        // this makes anchored side == cached side
+                        unsigned int dv_idx_anchoredOffset = Tanchored*dilSizeLS_.at(anchored_side) + jAnchor+jjAnchor; //offsetting time direction, then the block and the cache coordinates
                         START_TIMER("distil vectors");
                         makeDvLapSpinCacheBlock(dv.at(anchored_side),dv_idx_anchoredOffset,n_idx,epack,anchored_side,peramb);
                         STOP_TIMER("distil vectors");
@@ -1088,8 +1089,8 @@ void DmfComputation<FImpl,T,Tio>
                             DistilMatrixSetCache<T> cache(cBuf.data(), nExt_, nStr_, nt_, left_cache_size, right_cache_size);
 
                             //translate relative/anchored into left/right
-                            unsigned int left_dv_idx_offset  = (Side::left==relative_side)  ? iRel+iiRel : idx_dtAnchored*dilSizeLS_.at(anchored_side)+jAnchor+jjAnchor;
-                            unsigned int right_dv_idx_offset = (Side::right==relative_side) ? iRel+iiRel : idx_dtAnchored*dilSizeLS_.at(anchored_side)+jAnchor+jjAnchor;
+                            unsigned int left_dv_idx_offset  = (Side::left==relative_side)  ? iRel+iiRel : 0; //idx_dtAnchored*dilSizeLS_.at(anchored_side)+jAnchor+jjAnchor;
+                            unsigned int right_dv_idx_offset = (Side::right==relative_side) ? iRel+iiRel : 0; //idx_dtAnchored*dilSizeLS_.at(anchored_side)+jAnchor+jjAnchor;
 
                             double timer = 0.0;
                             START_TIMER("kernel");

--- a/Hadrons/DistilMatrix.hpp
+++ b/Hadrons/DistilMatrix.hpp
@@ -60,6 +60,8 @@
 
 #define HADRONS_DISTIL_PARALLEL_IO
 
+typedef unsigned int uint;
+
 BEGIN_HADRONS_NAMESPACE
 
 // general distil matrix set for io buffers
@@ -90,7 +92,7 @@ using DistilMatrixSetCache = A2AMatrixSet<T>;
 template <typename T>
 using DistilMesonFieldMatrix = Eigen::Matrix<T, -1, -1, Eigen::RowMajor>;
 
-using DilutionMap  = std::array<std::vector<std::vector<unsigned int>>,3>;
+using DilutionMap  = std::array<std::vector<std::vector<uint>>,3>;
 
 enum Side {left = 0, right = 1};
 const std::vector<Side> sides =  {Side::left,Side::right};  //for easy looping over sides
@@ -101,20 +103,20 @@ class DistilMesonFieldMetadata: Serializable
 {
 public:
     GRID_SERIALIZABLE_CLASS_MEMBERS(DistilMesonFieldMetadata,
-                                    unsigned int,                               Nt,
-                                    unsigned int,                               Nvec,
+                                    uint,                               Nt,
+                                    uint,                               Nvec,
                                     std::vector<RealF>,                         Momentum,
                                     Gamma::Algebra,                             Operator,               // potentially more general operators in the future
-                                    std::vector<unsigned int>,                  NoisePair,
+                                    std::vector<uint>,                  NoisePair,
                                     std::string,                                MesonFieldType,
                                     std::string,                                NoiseHashLeft,
                                     std::string,                                NoiseHashRight,
-                                    std::vector<std::vector<unsigned int>>,     TimeDilutionLeft,
-                                    std::vector<std::vector<unsigned int>>,     TimeDilutionRight,
-                                    std::vector<std::vector<unsigned int>>,     LapDilutionLeft,
-                                    std::vector<std::vector<unsigned int>>,     LapDilutionRight,
-                                    std::vector<std::vector<unsigned int>>,     SpinDilutionLeft,
-                                    std::vector<std::vector<unsigned int>>,     SpinDilutionRight,
+                                    std::vector<std::vector<uint>>,     TimeDilutionLeft,
+                                    std::vector<std::vector<uint>>,     TimeDilutionRight,
+                                    std::vector<std::vector<uint>>,     LapDilutionLeft,
+                                    std::vector<std::vector<uint>>,     LapDilutionRight,
+                                    std::vector<std::vector<uint>>,     SpinDilutionLeft,
+                                    std::vector<std::vector<uint>>,     SpinDilutionRight,
                                     std::string,                                RelativeSide,
                                     )
 };
@@ -128,8 +130,8 @@ class DistilMatrixIo
 public:
     // constructors
     DistilMatrixIo(void) = default;
-    DistilMatrixIo(std::string filename, std::string dataname, const unsigned int nt=0, const unsigned int ni = 0,
-                const unsigned int nj = 0);
+    DistilMatrixIo(std::string filename, std::string dataname, const uint nt=0, const uint ni = 0,
+                const uint nj = 0);
     // destructor
     ~DistilMatrixIo(void) = default;
     // access
@@ -139,27 +141,27 @@ public:
     template <typename MetadataType>
     void initFile(const MetadataType &d);
 
-    void saveBlock(const T *data, const unsigned int i, const unsigned int j,
-                   const unsigned int blockSizei, const unsigned int blockSizej, std::string t_name, std::string datasetName, const unsigned int chunkSize);
+    void saveBlock(const T *data, const uint i, const uint j,
+                   const uint blockSizei, const uint blockSizej, std::string t_name, std::string datasetName, const uint chunkSize);
 
-    void saveBlock(const DistilMatrixSetTimeSliceIo<T> &m, const unsigned int iextstr,
-                               const unsigned int i, const unsigned int j, std::string datasetName,
-                               const unsigned int t, const unsigned int chunkSize);
+    void saveBlock(const DistilMatrixSetTimeSliceIo<T> &m, const uint iextstr,
+                               const uint i, const uint j, std::string datasetName,
+                               const uint t, const uint chunkSize);
 
     template <template <class> class Vec, typename VecT>    // compatibility with A2A
-    void load(Vec<VecT> &v, const unsigned int t, const std::string dataset_name, double *tRead = nullptr, GridBase *grid = nullptr);
+    void load(Vec<VecT> &v, const uint t, const std::string dataset_name, double *tRead = nullptr, GridBase *grid = nullptr);
     template <typename Mat>
-    void load(Mat &v, const unsigned int t, const std::string dataset_name, double *tRead = nullptr, GridBase *grid = nullptr);
+    void load(Mat &v, const uint t, const std::string dataset_name, double *tRead = nullptr, GridBase *grid = nullptr);
 private:
     std::string  filename_{""}, dataname_{""};
-    unsigned int nt_{0}, ni_{0}, nj_{0};
+    uint nt_{0}, ni_{0}, nj_{0};
 };
 
 // implementation /////////////////////////////////////////////////////////////////
 template <typename T>
 DistilMatrixIo<T>::DistilMatrixIo(std::string filename, std::string dataname, 
-                            const unsigned int nt, const unsigned int ni,
-                            const unsigned int nj)
+                            const uint nt, const uint ni,
+                            const uint nj)
 : filename_(filename), dataname_(dataname), ni_(ni), nj_(nj), nt_(nt)
 {}
 
@@ -184,13 +186,13 @@ size_t DistilMatrixIo<T>::getSize(void) const
 
 template <typename T>
 void DistilMatrixIo<T>::saveBlock(const T *data, 
-                               const unsigned int i, 
-                               const unsigned int j,
-                               const unsigned int blockSizei,
-                               const unsigned int blockSizej,
+                               const uint i, 
+                               const uint j,
+                               const uint blockSizei,
+                               const uint blockSizej,
                                std::string t_name,
                                std::string datasetName,
-                               const unsigned int chunkSize)
+                               const uint chunkSize)
 {
 #ifdef HAVE_HDF5
     H5NS::H5File file(filename_,H5F_ACC_RDWR);
@@ -243,14 +245,14 @@ void DistilMatrixIo<T>::saveBlock(const T *data,
 
 template <typename T>
 void DistilMatrixIo<T>::saveBlock(const DistilMatrixSetTimeSliceIo<T> &m,
-                            //    const unsigned int ext, const unsigned int str,
-                               const unsigned int iextstr,  //local
-                               const unsigned int i, const unsigned int j, std::string datasetName,
-                               const unsigned int t, const unsigned int chunkSize)
+                            //    const uint ext, const uint str,
+                               const uint iextstr,  //local
+                               const uint i, const uint j, std::string datasetName,
+                               const uint t, const uint chunkSize)
 {
-    unsigned int blockSizei = m.dimension(1);
-    unsigned int blockSizej = m.dimension(2);
-    // unsigned int nextstr    = m.dimension(1);
+    uint blockSizei = m.dimension(1);
+    uint blockSizej = m.dimension(2);
+    // uint nextstr    = m.dimension(1);
     size_t       offset     = (iextstr*nt_ + t)*blockSizei*blockSizej;
 
     std::string t_name = std::to_string(t);
@@ -260,7 +262,7 @@ void DistilMatrixIo<T>::saveBlock(const DistilMatrixSetTimeSliceIo<T> &m,
 
 template <typename T>
 template <template <class> class Vec, typename VecT>
-void DistilMatrixIo<T>::load(Vec<VecT> &v, const unsigned int t, const std::string dataset_name, double *tRead, GridBase *grid)
+void DistilMatrixIo<T>::load(Vec<VecT> &v, const uint t, const std::string dataset_name, double *tRead, GridBase *grid)
 {
 #ifdef HAVE_HDF5
     std::vector<hsize_t> hdim;
@@ -292,8 +294,8 @@ void DistilMatrixIo<T>::load(Vec<VecT> &v, const unsigned int t, const std::stri
     }
     if (grid)
     {
-        grid->Broadcast(grid->BossRank(), &ni_, sizeof(unsigned int));
-        grid->Broadcast(grid->BossRank(), &nj_, sizeof(unsigned int));
+        grid->Broadcast(grid->BossRank(), &ni_, sizeof(uint));
+        grid->Broadcast(grid->BossRank(), &nj_, sizeof(uint));
     }
 
     DistilMesonFieldMatrix<T>         buf(ni_, nj_);
@@ -336,7 +338,7 @@ void DistilMatrixIo<T>::load(Vec<VecT> &v, const unsigned int t, const std::stri
 
 template <typename T>
 template <typename Mat>
-void DistilMatrixIo<T>::load(Mat &v, const unsigned int t, const std::string dataset_name, double *tRead, GridBase *grid)
+void DistilMatrixIo<T>::load(Mat &v, const uint t, const std::string dataset_name, double *tRead, GridBase *grid)
 {
 #ifdef HAVE_HDF5
     std::vector<hsize_t> hdim;
@@ -408,9 +410,9 @@ public:
     typedef std::vector<FermionField> DistilVector;
     typedef typename DistillationNoise::Index Index;
     typedef typename DistillationNoise::LapPack LapPack;
-    typedef std::function<std::string(const unsigned int, const unsigned int, const int, const int)>  TrajNumberFn;
-    typedef std::function<std::string(const unsigned int, const unsigned int, const int, const int)>  FilenameFn;
-    typedef std::function<DistilMesonFieldMetadata<FImpl>(const unsigned int, const unsigned int, const int, const int, DilutionMap, DilutionMap)>  MetadataFn;
+    typedef std::function<std::string(const uint, const uint, const int, const int)>  TrajNumberFn;
+    typedef std::function<std::string(const uint, const uint, const int, const int)>  FilenameFn;
+    typedef std::function<DistilMesonFieldMetadata<FImpl>(const uint, const uint, const int, const int, DilutionMap, DilutionMap)>  MetadataFn;
 public:
     long    blockCounter_ = 0;
     double  blockFlops_ = 0.0, blockBytes_ = 0.0, blockIoSpeed_ = 0.0;
@@ -420,17 +422,15 @@ private:
     GridCartesian*                      g3d_;
     ColourVectorField                   evec3d_;
     FermionField                        tmp3d_, tmp4d_;
-    // std::vector<Tio>                    bBuf_;
-    // std::vector<T>                      cBuf_;
-    const unsigned int                  blockSize_; //eventually turns into io chunk size
-    const unsigned int                  cacheSize_;
-    const unsigned int                  traj_;
-    const unsigned int                  nt_, nd_, nExt_, nStr_;
+    const uint                          blockSize_; //eventually turns into io chunk size
+    const uint                          cacheSize_;
+    const uint                          traj_;
+    const uint                          nt_, nd_, nExt_, nStr_;
     const bool                          isExact_;
     bool                                isInitFile_=false;
-    std::map<Side, unsigned int>        dilSizeLS_;
+    std::map<Side, uint>                dilSizeLS_;
     std::map<Side, DistillationNoise&>  distilNoise_;
-    const unsigned int                  dvBatchSize_ = DISTILVECTOR_TIME_BATCH_SIZE;
+    const uint                          dvBatchSize_ = DISTILVECTOR_TIME_BATCH_SIZE;
     std::map<Side, std::string>         vectorStem_={{Side::left,""},{Side::right,""}};
 public:
     DmfComputation(std::map<Side,std::string>   mf_type,
@@ -438,108 +438,113 @@ public:
                    GridCartesian*               g3d,
                    DistillationNoise&           nl,
                    DistillationNoise&           nr,
-                   const unsigned int           block_size,
-                   const unsigned int           cache_size,
-                   const unsigned int           nt,
-                   const unsigned int           n_ext,
-                   const unsigned int           n_str,
+                   const uint                   block_size,
+                   const uint                   cache_size,
+                   const uint                   nt,
+                   const uint                   n_ext,
+                   const uint                   n_str,
                    const bool                   is_exact,
-                   const unsigned int           traj,
+                   const uint                   traj,
                    const std::string            left_vector_stem="",
                    const std::string            right_vector_stem="");
     bool isPhi(Side s);
     bool isRho(Side s);
     DilutionMap fetchDilutionMap(Side s);
 private:
-    void makePhiComponent(FermionField&         phi_component,
-                          DistillationNoise&    n,
-                          const unsigned int    n_idx,
-                          const unsigned int    D,
-                          MDistil::PerambTensor&         peramb,
-                          LapPack&              epack);
-    void loadPhiComponent(FermionField&            phi_component,
-                          DistillationNoise&       n,
-                          const unsigned int       n_idx,
-                          const unsigned int       D,
-                          std::string              vector_stem,
-                          LapPack&                 epack);
+    void makePhiComponent(FermionField&             phi_component,
+                          DistillationNoise&        n,
+                          const uint                n_idx,
+                          const uint                D,
+                          MDistil::PerambTensor&    peramb,
+                          LapPack&                  epack);
+    void loadPhiComponent(FermionField&             phi_component,
+                          DistillationNoise&        n,
+                          const uint                n_idx,
+                          const uint                D,
+                          std::string               vector_stem,
+                          LapPack&                  epack);
     void makeRhoComponent(FermionField&         rho_component,
                           DistillationNoise&    n,
-                          const unsigned int    n_idx,
-                          const unsigned int    D);
-    void makeDvLapSpinBlock(std::map<Side, DistilVector&>               dv,
-                                      std::map<Side, unsigned int>      n_idx,
-                                      LapPack&                          epack,
-                                      Side                              s,
-                                      unsigned int                      dt,
-                                      unsigned int                      iibatch,
-                                      std::map<Side, MDistil::PerambTensor&>     peramb={});
-    void makeDvLapSpinCacheBlock(DistilVector&                      dv_cache,
-                               unsigned int                         dv_idx,
-                               std::map<Side, unsigned int>         n_idx,
-                               LapPack&                             epack,
-                               Side                                 s,
-                               std::map<Side, MDistil::PerambTensor&>        peramb);
+                          const uint            n_idx,
+                          const uint            D);
+    void makeDvLapSpinComponent(FermionField&                           component,
+                                std::map<Side, uint>                    n_idx,
+                                LapPack&                                epack,
+                                Side                                    s,
+                                uint                                    D,
+                                std::map<Side, MDistil::PerambTensor&>  peramb);
+    void makeDvLapSpinBlock(std::map<Side, DistilVector&>                       dv,
+                                      std::map<Side, uint>                      n_idx,
+                                      LapPack&                                  epack,
+                                      Side                                      s,
+                                      uint                                      dt,
+                                      uint                                      iibatch,
+                                      std::map<Side, MDistil::PerambTensor&>    peramb={});
+    void makeDvLapSpinCacheBlock(std::map<Side, DistilVector&>          dv,
+                               uint                                     dv_idx_offset,
+                               std::map<Side, uint>                     n_idx,
+                               LapPack&                                 epack,
+                               Side                                     s,
+                               std::map<Side, MDistil::PerambTensor&>   peramb);
     void makeDvLapSpinBatch(std::map<Side, DistilVector&>               dv,
-                                      std::map<Side, unsigned int>      n_idx,
-                                      LapPack&                          epack,
-                                      Side                              s,
-                                      std::vector<unsigned int>         dt_list,
-                                      std::map<Side, MDistil::PerambTensor&>     peramb);
-    std::vector<unsigned int> fetchDvBatchIdxs(unsigned int               ibatch,
-                                               std::vector<unsigned int>  time_dil_sources,
-                                               unsigned int                    shift=0);
-    void makeRelativePhiComponent(FermionField&                phi_component,
-                            DistillationNoise&               n,
-                            const unsigned int               n_idx,
-                            const unsigned int               D,
-                            const unsigned int               delta_t,
-                            std::map<Side, MDistil::PerambTensor&>                     peramb,
-                            Side                                     s,
-                            LapPack&                         epack,
-                            std::string                      vector_stem="");
-    void makeRelativeRhoComponent(FermionField&          rho_component,
-                            DistillationNoise&           n,
-                            const unsigned int           n_idx,
-                            const unsigned int           t,
-                            const unsigned int           D,
-                            LapPack&                     epack);
-    void makeRelativeDvLapSpinBlock(std::map<Side, DistilVector&>   dv,
-                               std::vector<unsigned int>            dt_list,
-                               std::map<Side, unsigned int>         n_idx,
-                               LapPack&                             epack,
-                               Side                                 s,
-                               const unsigned int                   delta_t,
-                               std::map<Side, MDistil::PerambTensor&>        peramb);
+                            std::map<Side, uint>                    n_idx,
+                            LapPack&                                epack,
+                            Side                                    s,
+                            std::vector<uint>                       dt_list,
+                            std::map<Side, MDistil::PerambTensor&>  peramb);
+    std::vector<uint> fetchDvBatchIdxs(uint                  ibatch,
+                                        std::vector<uint>    time_dil_sources,
+                                        uint                 shift=0);
+    void makeRelativePhiComponent(FermionField&                         phi_component,
+                                DistillationNoise&                      n,
+                                const uint                              n_idx,
+                                const uint                              D,
+                                const uint                              delta_t,
+                                std::map<Side, MDistil::PerambTensor&>  peramb,
+                                Side                                    s,
+                                LapPack&                                epack);
+    void makeRelativeRhoComponent(FermionField&         rho_component,
+                            DistillationNoise&          n,
+                            const uint                  n_idx,
+                            const uint                  t,
+                            const uint                  D,
+                            LapPack&                    epack);
+    void makeRelativeDvLapSpinBlock(std::map<Side, DistilVector&>       dv,
+                               std::vector<uint>                        dt_list,
+                               std::map<Side, uint>                     n_idx,
+                               LapPack&                                 epack,
+                               Side                                     s,
+                               const uint                               delta_t,
+                               std::map<Side, MDistil::PerambTensor&>   peramb);
 public:
-    void executeRelative(const FilenameFn&                            filenameDmfFn,
-                       const MetadataFn&                              metadataDmfFn,
-                       Vector<Tio>&                                   bBuf,
-                       Vector<T>&                                     cBuf,
-                       std::vector<Gamma::Algebra>                    gamma,
-                       std::map<Side, DistilVector&>                  dv,
-                       std::map<Side, unsigned int>                   n_idx,
-                       std::vector<ComplexField>                      ph,
-                       std::map<Side, std::vector<unsigned int>>      time_dil_source,
-                       LapPack&                                       epack,
-                       TimerArray*                                    tarray,
-                       Side                                           relative_side,
-                       std::vector<unsigned int>                      delta_t_list,
-                       std::map<Side, MDistil::PerambTensor&>                  peramb={});
+    void executeRelative(const FilenameFn&                              filenameDmfFn,
+                       const MetadataFn&                                metadataDmfFn,
+                       Vector<Tio>&                                     bBuf,
+                       Vector<T>&                                       cBuf,
+                       std::vector<Gamma::Algebra>                      gamma,
+                       std::map<Side, DistilVector&>                    dv,
+                       std::map<Side, uint>                             n_idx,
+                       std::vector<ComplexField>                        ph,
+                       std::map<Side, std::vector<uint>>                time_dil_source,
+                       LapPack&                                         epack,
+                       TimerArray*                                      tarray,
+                       Side                                             relative_side,
+                       std::vector<uint>                                delta_t_list,
+                       std::map<Side, MDistil::PerambTensor&>           peramb={});
     void executeFixed(const FilenameFn&                         filenameDmfFn,
                  const MetadataFn&                              metadataDmfFn,
                  Vector<Tio>&                                   bBuf,
                  Vector<T>&                                     cBuf,
                  std::vector<Gamma::Algebra>                    gamma,
                  std::map<Side, DistilVector&>                  dv,
-                 std::map<Side, unsigned int>                   n_idx,
+                 std::map<Side, uint>                           n_idx,
                  std::vector<ComplexField>                      ph,
-                 std::map<Side, std::vector<unsigned int>>      time_dil_source,
+                 std::map<Side, std::vector<uint>>              time_dil_source,
                  LapPack&                                       epack,
                  TimerArray*                                    tarray,
                  bool                                           only_diag,
-                 const unsigned int                             diag_shift,
-                 std::map<Side, MDistil::PerambTensor&>                  peramb={});
+                 const uint                                     diag_shift,
+                 std::map<Side, MDistil::PerambTensor&>         peramb={});
 };
 
 //####################################
@@ -553,22 +558,19 @@ DmfComputation<FImpl,T,Tio>
                  GridCartesian*                 g3d,
                  DistillationNoise&             nl,
                  DistillationNoise&             nr,
-                 const unsigned int             block_size,
-                 const unsigned int             cache_size,
-                 const unsigned int             nt,
-                 const unsigned int             n_ext,
-                 const unsigned int             n_str,
+                 const uint                     block_size,
+                 const uint                     cache_size,
+                 const uint                     nt,
+                 const uint                     n_ext,
+                 const uint                     n_str,
                  const bool                     is_exact,
-                 const unsigned int             traj,
+                 const uint                     traj,
                  const std::string              left_vector_stem,
                  const std::string              right_vector_stem)
 : dmfType_(mf_type), g_(g), g3d_(g3d), evec3d_(g3d), tmp3d_(g3d), tmp4d_(g)
 , nt_(nt) , nd_(g->Nd()), blockSize_(block_size) , cacheSize_(cache_size)
 , nExt_(n_ext) , nStr_(n_str) , isExact_(is_exact), traj_(traj)
 {
-    // cBuf_.resize(nExt_*nStr_*nt_*cacheSize_*cacheSize_);
-    // bBuf_.resize(nExt_*nStr_*nt_*blockSize_*blockSize_); //maximum size
-
     distilNoise_ = std::map<Side, DistillationNoise&> ({{Side::left,nl},{Side::right,nr}});
     dilSizeLS_ = { {Side::left,nl.dilutionSize(Index::l)*nl.dilutionSize(Index::s)} ,
                              {Side::right,nr.dilutionSize(Index::l)*nr.dilutionSize(Index::s)} };
@@ -581,9 +583,9 @@ DilutionMap DmfComputation<FImpl,T,Tio>::fetchDilutionMap(Side s)
 {
     DilutionMap m;
     for(auto dil_idx : { Index::t, Index::l, Index::s })
-    for(unsigned int it=0 ; it<distilNoise_.at(s).dilutionSize(dil_idx) ; it++)
+    for(uint it=0 ; it<distilNoise_.at(s).dilutionSize(dil_idx) ; it++)
     {
-        std::vector<unsigned int> temp = distilNoise_.at(s).dilutionPartition(dil_idx,it);
+        std::vector<uint> temp = distilNoise_.at(s).dilutionPartition(dil_idx,it);
         m[dil_idx].push_back(temp);
     }
     return m;
@@ -601,27 +603,40 @@ bool DmfComputation<FImpl,T,Tio>::isRho(Side s)
     return (dmfType_.at(s)=="rho" ? true : false);
 }
 
+// fetch time dilution indices (sources) in dv batch ibatch
+template <typename FImpl, typename T, typename Tio>
+std::vector<uint> DmfComputation<FImpl,T,Tio>
+::fetchDvBatchIdxs(uint ibatch, std::vector<uint> time_dil_sources, const uint shift)
+{
+    std::vector<uint> batch_dt;
+    for(uint dt=ibatch*dvBatchSize_; dt<(ibatch+1)*dvBatchSize_; dt++){
+        batch_dt.push_back( (time_dil_sources[dt]+shift)%distilNoise_.at(Side::right).dilutionSize(Index::t) );
+    }
+    return batch_dt;
+}
+
+// DV FIXED (ANCHORED) METHODS
 template <typename FImpl, typename T, typename Tio>
 void DmfComputation<FImpl,T,Tio>
 ::makePhiComponent(FermionField&            phi_component,
                    DistillationNoise&       n,
-                   const unsigned int       n_idx,
-                   const unsigned int       D,
-                   MDistil::PerambTensor&            peramb,
+                   const uint               n_idx,
+                   const uint               D,
+                   MDistil::PerambTensor&   peramb,
                    LapPack&                 epack)
 {
-    std::array<unsigned int,3> d_coor = n.dilutionCoordinates(D);
-    unsigned int dt = d_coor[Index::t] , dk = d_coor[Index::l] , ds = d_coor[Index::s];
+    std::array<uint,3> d_coor = n.dilutionCoordinates(D);
+    uint dt = d_coor[Index::t] , dk = d_coor[Index::l] , ds = d_coor[Index::s];
     std::vector<int> peramb_ts = peramb.MetaData.timeSources;
     std::vector<int>::iterator itr_dt = std::find(peramb_ts.begin(), peramb_ts.end(), dt);
-    unsigned int idt = std::distance(peramb_ts.begin(), itr_dt); //gets correspondent index of dt in the tensor obj 
-    const unsigned int nVec = epack.evec.size();
-    const unsigned int Nt_first = g_->LocalStarts()[nd_ - 1];
-    const unsigned int Nt_local = g_->LocalDimensions()[nd_ - 1];
-    for (unsigned int t = Nt_first; t < Nt_first + Nt_local; t++)
+    uint idt = std::distance(peramb_ts.begin(), itr_dt); //gets correspondent index of dt in the tensor obj 
+    const uint nVec = epack.evec.size();
+    const uint Nt_first = g_->LocalStarts()[nd_ - 1];
+    const uint Nt_local = g_->LocalDimensions()[nd_ - 1];
+    for (uint t = Nt_first; t < Nt_first + Nt_local; t++)
     {
         tmp3d_ = Zero();
-        for (unsigned int k = 0; k < nVec; k++)
+        for (uint k = 0; k < nVec; k++)
         {
             ExtractSliceLocal(evec3d_,epack.evec[k],0,t-Nt_first,nd_ - 1);
             tmp3d_ += evec3d_ * peramb.tensor(t, k, dk, n_idx, idt, ds);
@@ -634,12 +649,12 @@ template <typename FImpl, typename T, typename Tio>
 void DmfComputation<FImpl,T,Tio>
 ::loadPhiComponent(FermionField&            phi_component,
                    DistillationNoise&       n,
-                   const unsigned int       n_idx,
-                   const unsigned int       D,
+                   const uint               n_idx,
+                   const uint               D,
                    std::string              vector_stem,
                    LapPack&                 epack)
 {
-    const unsigned int nVec = epack.evec.size();
+    const uint nVec = epack.evec.size();
     DistillationVectorsIo::readComponent(phi_component, vector_stem + "_noise" + std::to_string(n_idx) , n.size(),
                                     n.dilutionSize(Index::l), n.dilutionSize(Index::s), n.dilutionSize(Index::t), D, traj_);
 }
@@ -648,143 +663,135 @@ template <typename FImpl, typename T, typename Tio>
 void DmfComputation<FImpl,T,Tio>
 ::makeRhoComponent(FermionField&        rho_component,
                    DistillationNoise&   n,
-                   const unsigned int   n_idx,
-                   const unsigned int   D)   
+                   const uint           n_idx,
+                   const uint           D)   
 {
     rho_component = n.makeSource(D, n_idx);
+}
+
+
+template <typename FImpl, typename T, typename Tio>
+void DmfComputation<FImpl,T,Tio>
+::makeDvLapSpinComponent(FermionField&                          component,
+                        std::map<Side, uint>                    n_idx,
+                        LapPack&                                epack,
+                        Side                                    s,
+                        uint                                    D,
+                        std::map<Side, MDistil::PerambTensor&>  peramb)
+{
+    if(isPhi(s))
+    {
+        if(vectorStem_.at(s).empty())
+        {
+            makePhiComponent(component , distilNoise_.at(s) , n_idx.at(s) , D , peramb.at(s), epack);
+        }
+        else
+        {
+            loadPhiComponent(component , distilNoise_.at(s) , n_idx.at(s) , D , vectorStem_.at(s), epack);
+        }
+    }
+    else if(isRho(s))
+    {
+        makeRhoComponent(component, distilNoise_.at(s) , n_idx.at(s) , D);
+    }
 }
 
 // lap-spin blocks have fixed dimensions of (lap-spin dilution size left)x(lap-spin dilution size right)
 // and each is identified by the starting posision in time dilution space, (dtL,dtR)
 template <typename FImpl, typename T, typename Tio>
 void DmfComputation<FImpl,T,Tio>
-::makeDvLapSpinBlock(std::map<Side, DistilVector&>                  dv,
-                               std::map<Side, unsigned int>         n_idx,
-                               LapPack&                             epack,
-                               Side                                 s,
-                               unsigned int                         dt,
-                               unsigned int                         iibatch,
-                               std::map<Side, MDistil::PerambTensor&>        peramb)
+::makeDvLapSpinBlock(std::map<Side, DistilVector&>                      dv,
+                               std::map<Side, uint>                     n_idx,
+                               LapPack&                                 epack,
+                               Side                                     s,
+                               uint                                     dt,
+                               uint                                     iibatch,
+                               std::map<Side, MDistil::PerambTensor&>   peramb)
 {
-    unsigned int D_offset = distilNoise_.at(s).dilutionIndex(dt,0,0);    // t is the slowest index
-    unsigned int iD_offset = iibatch*dilSizeLS_.at(s);
-    for(unsigned int iD=iD_offset ; iD<iD_offset+dilSizeLS_.at(s) ; iD++)
+    uint D_offset = distilNoise_.at(s).dilutionIndex(dt,0,0);    // t is the slowest index
+    uint iD_offset = iibatch*dilSizeLS_.at(s);
+
+    for(uint iD=iD_offset ; iD<iD_offset+dilSizeLS_.at(s) ; iD++)
     {
-        unsigned int D = (iD - iD_offset) + D_offset ;
-        if(isPhi(s))
-        {
-            if(vectorStem_.at(s).empty())
-            {
-                makePhiComponent(dv.at(s)[iD] , distilNoise_.at(s) , n_idx.at(s) , D , peramb.at(s), epack);
-            }
-            else
-            {
-                loadPhiComponent(dv.at(s)[iD] , distilNoise_.at(s) , n_idx.at(s) , D , vectorStem_.at(s), epack);
-            }
-        }
-        else if(isRho(s))
-        {
-            makeRhoComponent(dv.at(s)[iD] , distilNoise_.at(s) , n_idx.at(s) , D);
-        }
+        uint D = (iD - iD_offset) + D_offset ;
+        makeDvLapSpinComponent(dv.at(s)[iD], n_idx, epack, s, D, peramb);
     }
 }
-//makeDvLapSpinCacheBlock(dv.at(Side::left)[0],n_idx,epack,batch_dtL,peramb);
+
 template <typename FImpl, typename T, typename Tio>
 void DmfComputation<FImpl,T,Tio>
-::makeDvLapSpinCacheBlock(DistilVector&                             dv_cache,
-                               unsigned int                         dv_idx, //offset variable
-                               std::map<Side, unsigned int>         n_idx,
-                               LapPack&                             epack,
-                               Side                                 s,
-                               std::map<Side, MDistil::PerambTensor&>        peramb)
+::makeDvLapSpinCacheBlock(std::map<Side, DistilVector&>                     dv,
+                               uint                                         dv_idx_offset, //offset variable
+                               std::map<Side, uint>                         n_idx,
+                               LapPack&                                     epack,
+                               Side                                         s,
+                               std::map<Side, MDistil::PerambTensor&>       peramb)
 {
-    for(unsigned int iD=0 ; iD<cacheSize_ ; iD++)
+    for(uint iD=0 ; iD<cacheSize_ ; iD++)
     {
-        unsigned int D = iD + dv_idx;
-        if(isPhi(s))
-        {
-            if(vectorStem_.at(s).empty())
-            {
-                makePhiComponent(dv_cache[iD] , distilNoise_.at(s) , n_idx.at(s) , D , peramb.at(s), epack);
-            }
-            else
-            {
-                loadPhiComponent(dv_cache[iD] , distilNoise_.at(s) , n_idx.at(s) , D , vectorStem_.at(s), epack);
-            }
-        }
-        else if(isRho(s))
-        {
-            makeRhoComponent(dv_cache[iD] , distilNoise_.at(s) , n_idx.at(s) , D);
-        }
+        uint D = iD + dv_idx_offset;
+        makeDvLapSpinComponent(dv.at(s)[iD], n_idx, epack, s, D, peramb);
     }
 }
 
 // a batch is composed of several lap-spin blocks
 template <typename FImpl, typename T, typename Tio>
 void DmfComputation<FImpl,T,Tio>
-::makeDvLapSpinBatch(std::map<Side, DistilVector&>              dv,
-                               std::map<Side, unsigned int>     n_idx,
-                               LapPack&                         epack,
-                               Side                             s,
-                               std::vector<unsigned int>        dt_list,
-                               std::map<Side, MDistil::PerambTensor&>    peramb)
+::makeDvLapSpinBatch(std::map<Side, DistilVector&>                      dv,
+                               std::map<Side, uint>                     n_idx,
+                               LapPack&                                 epack,
+                               Side                                     s,
+                               std::vector<uint>                        dt_list,
+                               std::map<Side, MDistil::PerambTensor&>   peramb)
 {
-    for(unsigned int idt=0 ; idt<dt_list.size() ; idt++)
+    for(uint idt=0 ; idt<dt_list.size() ; idt++)
     {
         makeDvLapSpinBlock(dv,n_idx,epack,s,dt_list[idt],idt,peramb);
     }
 }
 
-// fetch time dilution indices (sources) in dv batch ibatch
-template <typename FImpl, typename T, typename Tio>
-std::vector<unsigned int> DmfComputation<FImpl,T,Tio>
-::fetchDvBatchIdxs(unsigned int ibatch, std::vector<unsigned int> time_dil_sources, const unsigned int shift)
-{
-    std::vector<unsigned int> batch_dt;
-    for(unsigned int dt=ibatch*dvBatchSize_; dt<(ibatch+1)*dvBatchSize_; dt++){
-        batch_dt.push_back( (time_dil_sources[dt]+shift)%distilNoise_.at(Side::right).dilutionSize(Index::t) );
-    }
-    return batch_dt;
-}
+
+// DV RELATIVE METHODS
+
+// nb: methods making relative components just insert a couple of timeslices (1 for full time dilution) on the field 
 
 // makeRelative methods build distil vectors with reorganised time slices
 // (in order to compute multiple time-dilution blocks at different t with a single call of MesonField kernel)
 template <typename FImpl, typename T, typename Tio>
 void DmfComputation<FImpl,T,Tio>
-::makeRelativePhiComponent(FermionField&            phi_component,
-                   DistillationNoise&               n,
-                   const unsigned int               n_idx,
-                   const unsigned int               D,
-                   const unsigned int               delta_t,
-                   std::map<Side, MDistil::PerambTensor&>            peramb,
-                   Side                             s,
-                   LapPack&                         epack,
-                   std::string                      vector_stem)
+::makeRelativePhiComponent(FermionField&                    phi_component,
+                   DistillationNoise&                       n,
+                   const uint                               n_idx,
+                   const uint                               D,
+                   const uint                               delta_t,
+                   std::map<Side, MDistil::PerambTensor&>   peramb,
+                   Side                                     s,
+                   LapPack&                                 epack)
 {
-    std::array<unsigned int,3> d_coor = n.dilutionCoordinates(D);
-    unsigned int dt = d_coor[Index::t] , dk = d_coor[Index::l] , ds = d_coor[Index::s];
-    if(!vector_stem.empty())
+    std::array<uint,3> d_coor = n.dilutionCoordinates(D);
+    uint dt = d_coor[Index::t] , dk = d_coor[Index::l] , ds = d_coor[Index::s];
+    if(!vectorStem_.at(s).empty())
     {
-        loadPhiComponent(tmp4d_, n , n_idx , D , vector_stem , epack);    // potentially io demanding
+        loadPhiComponent(tmp4d_, n , n_idx , D , vectorStem_.at(s) , epack);    // potentially io demanding
     }
     
     //compute at relative_time, insert at t=relative_time
-    const unsigned int relative_time    = (dt + delta_t)%nt_;               //TODO: generalise to dilution
-    const unsigned int t                = relative_time;
+    const uint relative_time    = (dt + delta_t)%nt_;               //TODO: generalise to dilution
+    const uint t                = relative_time;
      
-    const unsigned int nVec = epack.evec.size();
-    const unsigned int Nt_first = g_->LocalStarts()[nd_ - 1];
-    const unsigned int Nt_local = g_->LocalDimensions()[nd_ - 1];
+    const uint nVec = epack.evec.size();
+    const uint Nt_first = g_->LocalStarts()[nd_ - 1];
+    const uint Nt_local = g_->LocalDimensions()[nd_ - 1];
     if( (relative_time>=Nt_first) and (relative_time<Nt_first+Nt_local) )
     {
         tmp3d_ = Zero();
-        for (unsigned int k = 0; k < nVec; k++)
+        for (uint k = 0; k < nVec; k++)
         {
-            if(vector_stem.empty())
+            if(vectorStem_.at(s).empty())
             {
                 std::vector<int> peramb_ts = peramb.at(s).MetaData.timeSources;
                 std::vector<int>::iterator itr_dt = std::find(peramb_ts.begin(), peramb_ts.end(), dt);
-                unsigned int idt_peramb = std::distance(peramb_ts.begin(), itr_dt); //gets correspondent index of dt in the tensor obj 
+                uint idt_peramb = std::distance(peramb_ts.begin(), itr_dt); //gets correspondent index of dt in the tensor obj 
                 ExtractSliceLocal(evec3d_,epack.evec[k],0,relative_time-Nt_first,nd_ - 1);
                 tmp3d_ += evec3d_ * peramb.at(s).tensor(relative_time, k, dk, n_idx, idt_peramb, ds);
             }
@@ -799,26 +806,26 @@ void DmfComputation<FImpl,T,Tio>
 
 template <typename FImpl, typename T, typename Tio>
 void DmfComputation<FImpl,T,Tio>
-::makeRelativeRhoComponent(FermionField&        rho_component,
-                   DistillationNoise&           n,
-                   const unsigned int           n_idx,
-                   const unsigned int           D,
-                   const unsigned int           delta_t,
-                   LapPack&                     epack)
+::makeRelativeRhoComponent(FermionField&    rho_component,
+                   DistillationNoise&       n,
+                   const uint               n_idx,
+                   const uint               D,
+                   const uint               delta_t,
+                   LapPack&                 epack)
 {
     // abstract this to makeRelativeSource() kind of method in DilutedNoise?
-    std::array<unsigned int,3> d_coor = n.dilutionCoordinates(D);
-    unsigned int dt = d_coor[Index::t] , dk = d_coor[Index::l] , ds = d_coor[Index::s];
+    std::array<uint,3> d_coor = n.dilutionCoordinates(D);
+    uint dt = d_coor[Index::t] , dk = d_coor[Index::l] , ds = d_coor[Index::s];
 
     typename DistillationNoise::NoiseType   noise(n.getNoise()[n_idx].data(), nt_, epack.eval.size(), Ns);
 
     //compute at relative_time, insert at t
-    const unsigned int relative_time = (dt + delta_t)%nt_;     //TODO: generalise to non-full dilution
-    const unsigned int t        = relative_time;
+    const uint relative_time = (dt + delta_t)%nt_;     //TODO: generalise to non-full dilution
+    const uint t        = relative_time;
 
     // adapt to dilution! (add an it loop and untrivialise ik and is loops)
-    const unsigned int Nt_first = g_->LocalStarts()[nd_ - 1];
-    const unsigned int Nt_local = g_->LocalDimensions()[nd_ - 1];
+    const uint Nt_first = g_->LocalStarts()[nd_ - 1];
+    const uint Nt_local = g_->LocalDimensions()[nd_ - 1];
     if( (relative_time>=Nt_first) and (relative_time<Nt_first+Nt_local) )
     {
         for (auto ik : n.dilutionPartition(Index::l, dk))
@@ -840,30 +847,30 @@ void DmfComputation<FImpl,T,Tio>
 template <typename FImpl, typename T, typename Tio>
 void DmfComputation<FImpl,T,Tio>
 ::makeRelativeDvLapSpinBlock(std::map<Side, DistilVector&>              dv,
-                               std::vector<unsigned int>                dt_list,
-                               std::map<Side, unsigned int>             n_idx,
+                               std::vector<uint>                        dt_list,
+                               std::map<Side, uint>                     n_idx,
                                LapPack&                                 epack,
                                Side                                     s,
-                               const unsigned int                       delta_t,
-                               std::map<Side, MDistil::PerambTensor&>            peramb)
+                               const uint                               delta_t,
+                               std::map<Side, MDistil::PerambTensor&>   peramb)
 {
-    for(unsigned int D=0 ; D<dilSizeLS_.at(s) ; D++)
+    for(uint D=0 ; D<dilSizeLS_.at(s) ; D++)    // reset dv
         dv.at(s)[D] = Zero();
 
-    for(unsigned int D=0 ; D<distilNoise_.at(s).dilutionSize() ; D++)
+    for(uint D=0 ; D<distilNoise_.at(s).dilutionSize() ; D++) //loop over all (dt,dk,ds) compound indices
     {
-        std::array<unsigned int,3> d_coor = distilNoise_.at(s).dilutionCoordinates(D);
-        unsigned int dt = d_coor[Index::t] , dk = d_coor[Index::l] , ds = d_coor[Index::s];
-        if( std::count(dt_list.begin(), dt_list.end(), dt)!=0 )
+        std::array<uint,3> d_coor = distilNoise_.at(s).dilutionCoordinates(D);
+        uint dt = d_coor[Index::t] , dk = d_coor[Index::l] , ds = d_coor[Index::s];
+        if( std::count(dt_list.begin(), dt_list.end(), dt)!=0 ) // select the dt's wanted here: they will correspond to different timeslices of a single dt component
         {
-            const unsigned int Drelative = distilNoise_.at(s).dilutionIndex(0,dk,ds);
+            const uint Drelative = distilNoise_.at(s).dilutionIndex(0,dk,ds);
             if(isPhi(s))
             {
-                makeRelativePhiComponent(dv.at(s)[Drelative] , distilNoise_.at(s) , n_idx.at(s) , D , delta_t , peramb, s, epack, vectorStem_.at(s));
+                makeRelativePhiComponent(dv.at(s)[Drelative], distilNoise_.at(s), n_idx.at(s), D , delta_t, peramb, s, epack);
             }
             else if(isRho(s))
             {
-                makeRelativeRhoComponent(dv.at(s)[Drelative] , distilNoise_.at(s) , n_idx.at(s), D, delta_t , epack);
+                makeRelativeRhoComponent(dv.at(s)[Drelative], distilNoise_.at(s), n_idx.at(s), D, delta_t, epack);
             }
         }
     }
@@ -871,27 +878,27 @@ void DmfComputation<FImpl,T,Tio>
 
 template <typename FImpl, typename T, typename Tio>
 void DmfComputation<FImpl,T,Tio>
-::executeRelative(const FilenameFn&                           filenameDmfFn,
-                const MetadataFn&                             metadataDmfFn,
-                Vector<Tio>&                                  bBuf,
-                Vector<T>&                                    cBuf,
-                std::vector<Gamma::Algebra>                   gamma,
-                std::map<Side, DistilVector&>                 dv,
-                std::map<Side, unsigned int>                  n_idx,
-                std::vector<ComplexField>                     ph,
-                std::map<Side, std::vector<unsigned int>>     time_dil_source,
-                LapPack&                                      epack,
-                TimerArray*                                   tarray,
-                Side                                          relative_side,
-                std::vector<unsigned int>                     delta_t_list,
-                std::map<Side, MDistil::PerambTensor&>                 peramb)
+::executeRelative(const FilenameFn&                         filenameDmfFn,
+                const MetadataFn&                           metadataDmfFn,
+                Vector<Tio>&                                bBuf,
+                Vector<T>&                                  cBuf,
+                std::vector<Gamma::Algebra>                 gamma,
+                std::map<Side, DistilVector&>               dv,
+                std::map<Side, uint>                        n_idx,
+                std::vector<ComplexField>                   ph,
+                std::map<Side, std::vector<uint>>           time_dil_source,
+                LapPack&                                    epack,
+                TimerArray*                                 tarray,
+                Side                                        relative_side,
+                std::vector<uint>                           delta_t_list,
+                std::map<Side, MDistil::PerambTensor&>      peramb)
 {
-    const unsigned int vol = g_->_gsites;
+    const uint vol = g_->_gsites;
     //parallel IO info
-    const unsigned int i_rank = g_->ThisRank();
-    const unsigned int N_ranks = g_->RankCount();
-    const unsigned int nExtStr = nExt_*nStr_;
-    const unsigned int nExtStrLocal = g_->IsBoss() ? nExtStr/N_ranks 
+    const uint i_rank = g_->ThisRank();
+    const uint N_ranks = g_->RankCount();
+    const uint nExtStr = nExt_*nStr_;
+    const uint nExtStrLocal = g_->IsBoss() ? nExtStr/N_ranks 
                                         + nExtStr%N_ranks : nExtStr/N_ranks; // put remainder in boss node
 
     Side anchored_side = (Side::right==relative_side ? Side::left : Side::right);
@@ -903,13 +910,13 @@ void DmfComputation<FImpl,T,Tio>
         STOP_TIMER("distil vectors");
 
         //loop over left dv batches
-        for (unsigned int ibatchAnchored=0 ; ibatchAnchored<time_dil_source.at(anchored_side).size()/dvBatchSize_ ; ibatchAnchored++)
+        for (uint ibatchAnchored=0 ; ibatchAnchored<time_dil_source.at(anchored_side).size()/dvBatchSize_ ; ibatchAnchored++)
         { 
-            std::vector<unsigned int> batch_dtAnchored;
+            std::vector<uint> batch_dtAnchored;
             batch_dtAnchored = fetchDvBatchIdxs(ibatchAnchored,time_dil_source.at(anchored_side));
-            for (unsigned int idx_dtAnchored=0 ; idx_dtAnchored<batch_dtAnchored.size() ; idx_dtAnchored++)
+            for (uint idx_dtAnchored=0 ; idx_dtAnchored<batch_dtAnchored.size() ; idx_dtAnchored++)
             {
-                unsigned int Tanchored = batch_dtAnchored[idx_dtAnchored];
+                uint Tanchored = batch_dtAnchored[idx_dtAnchored];
 
                 if(Side::right==relative_side)
                 {
@@ -921,21 +928,21 @@ void DmfComputation<FImpl,T,Tio>
                 }
                 LOG(Message) << "Time shift (deltaT) : " << delta_t << std::endl; 
 
-                unsigned int nblockRel = dilSizeLS_.at(relative_side)/blockSize_ + (((dilSizeLS_.at(relative_side) % blockSize_) != 0) ? 1 : 0);
-                unsigned int nblockAnchor = dilSizeLS_.at(anchored_side)/blockSize_ + (((dilSizeLS_.at(anchored_side) % blockSize_) != 0) ? 1 : 0);
+                uint nblockRel = dilSizeLS_.at(relative_side)/blockSize_ + (((dilSizeLS_.at(relative_side) % blockSize_) != 0) ? 1 : 0);
+                uint nblockAnchor = dilSizeLS_.at(anchored_side)/blockSize_ + (((dilSizeLS_.at(anchored_side) % blockSize_) != 0) ? 1 : 0);
 
                 // loop over blocks within the current time-dilution block
-                for(unsigned int iRel=0 ; iRel<dilSizeLS_.at(relative_side) ; iRel+=blockSize_) //set according to memory size
-                for(unsigned int jAnchor=0 ; jAnchor<dilSizeLS_.at(anchored_side) ; jAnchor+=blockSize_)
+                for(uint iRel=0 ; iRel<dilSizeLS_.at(relative_side) ; iRel+=blockSize_) //set according to memory size
+                for(uint jAnchor=0 ; jAnchor<dilSizeLS_.at(anchored_side) ; jAnchor+=blockSize_)
                 {
                     double flops=0.0, bytes=0.0, time_kernel=0.0, nodes=g_->NodeCount();
                     // rel_block_size is the size of the current block (indexed by iRel); N_i-iRel is the size of the possible remainder block
-                    unsigned int rel_block_size = MIN(dilSizeLS_.at(relative_side)-iRel,blockSize_);
-                    unsigned int anchor_block_size = MIN(dilSizeLS_.at(anchored_side)-jAnchor,blockSize_);
+                    uint rel_block_size = MIN(dilSizeLS_.at(relative_side)-iRel,blockSize_);
+                    uint anchor_block_size = MIN(dilSizeLS_.at(anchored_side)-jAnchor,blockSize_);
 
                     //translate relative/anchored into left/right
-                    unsigned int left_block_size = (Side::left==relative_side) ? rel_block_size : anchor_block_size;
-                    unsigned int right_block_size = (Side::right==relative_side) ? rel_block_size : anchor_block_size;
+                    uint left_block_size = (Side::left==relative_side) ? rel_block_size : anchor_block_size;
+                    uint right_block_size = (Side::right==relative_side) ? rel_block_size : anchor_block_size;
                     DistilMatrixSetIo<Tio> block(bBuf.data(), nExtStrLocal , nt_, left_block_size, right_block_size);
 
                     LOG(Message) << "Distil matrix block" 
@@ -945,30 +952,30 @@ void DmfComputation<FImpl,T,Tio>
                     << std::endl;
 
                     // loop over cache blocks within the current block
-                    for(unsigned int jjAnchor=0 ; jjAnchor<anchor_block_size ; jjAnchor+=cacheSize_)
+                    for(uint jjAnchor=0 ; jjAnchor<anchor_block_size ; jjAnchor+=cacheSize_)
                     // cached dv computation needs to be done here, so it doesnt repeat unnecessarily on inner loop
                     // jAnchor and jjAnchor needs to be associated with anchored_side: can be either left or right!
                     {
-                        //fine here, but need to make sure remaining code treats jAnchor,jjAnchor as the anchored side (not right side necessarily)
+                        // need to make sure remaining code treats jAnchor,jjAnchor as the anchored side (not the right side necessarily)
                         // this makes anchored side == cached side
-                        unsigned int dv_idx_anchoredOffset = Tanchored*dilSizeLS_.at(anchored_side) + jAnchor+jjAnchor; //offsetting time direction, then the block and the cache coordinates
+                        uint dv_idx_anchored_offset = Tanchored*dilSizeLS_.at(anchored_side) + jAnchor+jjAnchor; //offsetting time direction, then the block and the cache coordinates
                         START_TIMER("distil vectors");
-                        makeDvLapSpinCacheBlock(dv.at(anchored_side),dv_idx_anchoredOffset,n_idx,epack,anchored_side,peramb);
+                        makeDvLapSpinCacheBlock(dv,dv_idx_anchored_offset,n_idx,epack,anchored_side,peramb);
                         STOP_TIMER("distil vectors");
 
-                        for(unsigned int iiRel=0 ; iiRel<rel_block_size ; iiRel+=cacheSize_)
+                        for(uint iiRel=0 ; iiRel<rel_block_size ; iiRel+=cacheSize_)
                         {
-                            unsigned int rel_cache_size = MIN(rel_block_size-iiRel,cacheSize_);      
-                            unsigned int anchor_cache_size = MIN(anchor_block_size-jjAnchor,cacheSize_);
+                            uint rel_cache_size = MIN(rel_block_size-iiRel,cacheSize_);      
+                            uint anchor_cache_size = MIN(anchor_block_size-jjAnchor,cacheSize_);
 
                             //translate relative/anchored into left/right
-                            unsigned int left_cache_size = (Side::left==relative_side) ? rel_cache_size : anchor_cache_size;
-                            unsigned int right_cache_size = (Side::right==relative_side) ? rel_cache_size : anchor_cache_size;
+                            uint left_cache_size = (Side::left==relative_side) ? rel_cache_size : anchor_cache_size;
+                            uint right_cache_size = (Side::right==relative_side) ? rel_cache_size : anchor_cache_size;
                             DistilMatrixSetCache<T> cache(cBuf.data(), nExt_, nStr_, nt_, left_cache_size, right_cache_size);
 
                             //translate relative/anchored into left/right
-                            unsigned int left_dv_idx_offset  = (Side::left==relative_side)  ? iRel+iiRel : 0; //idx_dtAnchored*dilSizeLS_.at(anchored_side)+jAnchor+jjAnchor;
-                            unsigned int right_dv_idx_offset = (Side::right==relative_side) ? iRel+iiRel : 0; //idx_dtAnchored*dilSizeLS_.at(anchored_side)+jAnchor+jjAnchor;
+                            uint left_dv_idx_offset  = (Side::left==relative_side)  ? iRel+iiRel : 0;
+                            uint right_dv_idx_offset = (Side::right==relative_side) ? iRel+iiRel : 0;
 
                             double timer = 0.0;
                             START_TIMER("kernel");
@@ -984,19 +991,19 @@ void DmfComputation<FImpl,T,Tio>
                             //// copy cache to ioblock
 
                             //translate relative/anchored into left/right
-                            unsigned int left_ii   = (Side::left==relative_side)  ? iiRel : jjAnchor;
-                            unsigned int right_jj  = (Side::right==relative_side) ? iiRel : jjAnchor;
+                            uint left_ii   = (Side::left==relative_side)  ? iiRel : jjAnchor;
+                            uint right_jj  = (Side::right==relative_side) ? iiRel : jjAnchor;
 
                             g_->Barrier();
                             START_TIMER("cache copy");
                             thread_for_collapse(4,iextstr_local,nExtStrLocal,{
-                            for(unsigned int t=0;t<nt_;t++)
-                            for(unsigned int iii=0;iii<left_cache_size;iii++)
-                            for(unsigned int jjj=0;jjj<right_cache_size;jjj++)
+                            for(uint t=0;t<nt_;t++)
+                            for(uint iii=0;iii<left_cache_size;iii++)
+                            for(uint jjj=0;jjj<right_cache_size;jjj++)
                             {
-                                const unsigned int iextstr = iextstr_local + i_rank * nExtStrLocal + (g_->IsBoss() ? 0 : nExtStr%N_ranks );
-                                const unsigned int iext = iextstr/nStr_;
-                                const unsigned int istr = iextstr%nStr_;
+                                const uint iextstr = iextstr_local + i_rank * nExtStrLocal + (g_->IsBoss() ? 0 : nExtStr%N_ranks );
+                                const uint iext = iextstr/nStr_;
+                                const uint istr = iextstr%nStr_;
                                 block(iextstr_local,t,left_ii+iii,right_jj+jjj) = cache(iext,istr,t,iii,jjj);
                             }
                             });
@@ -1015,18 +1022,18 @@ void DmfComputation<FImpl,T,Tio>
 
                     // io section
                     LOG(Message) << "Starting parallel IO. Rank count=" << N_ranks << std::endl;
-                    for(unsigned int it=0 ; it<time_dil_source.at(relative_side).size() ; it++)
+                    for(uint it=0 ; it<time_dil_source.at(relative_side).size() ; it++)
                     {
                         // TODO: generalise to dilution
-                        unsigned int t = (time_dil_source.at(relative_side)[it] + delta_t)%nt_;
-                        const unsigned int Trelative = time_dil_source.at(relative_side)[it];
+                        uint t = (time_dil_source.at(relative_side)[it] + delta_t)%nt_;
+                        const uint Trelative = time_dil_source.at(relative_side)[it];
 
                         DistilMatrixSetTimeSliceIo<Tio> block_relative(bBuf.data(), nExtStrLocal , rel_block_size, anchor_block_size);
                         std::string dataset_name = std::to_string( (Side::right==relative_side) ? Tanchored : Trelative ) 
                             + "-" + std::to_string( (Side::right==relative_side) ? Trelative : Tanchored );
 
-                        std::vector<unsigned int> relative_partition = distilNoise_.at(relative_side).dilutionPartition(Index::t,Trelative);
-                        std::vector<unsigned int> anchored_partition = distilNoise_.at(anchored_side).dilutionPartition(Index::t,Tanchored);
+                        std::vector<uint> relative_partition = distilNoise_.at(relative_side).dilutionPartition(Index::t,Trelative);
+                        std::vector<uint> anchored_partition = distilNoise_.at(anchored_side).dilutionPartition(Index::t,Tanchored);
 
                         if( !( isRho(relative_side) and std::count(relative_partition.begin(), relative_partition.end(), t)==0  ) 
                             and !(isRho(anchored_side) and std::count(anchored_partition.begin(), anchored_partition.end(), t)==0) )
@@ -1037,11 +1044,11 @@ void DmfComputation<FImpl,T,Tio>
                             START_TIMER("IO: total");
 #ifdef HADRONS_DISTIL_PARALLEL_IO
                             g_->Barrier();
-                            for(unsigned int iextstr_local=0 ; iextstr_local<nExtStrLocal ; iextstr_local++)
+                            for(uint iextstr_local=0 ; iextstr_local<nExtStrLocal ; iextstr_local++)
                             {
-                                const unsigned int iextstr = iextstr_local + i_rank * nExtStrLocal + (g_->IsBoss() ? 0 : nExtStr%N_ranks );
-                                const unsigned int iext = iextstr/nStr_;
-                                const unsigned int istr = iextstr%nStr_;
+                                const uint iextstr = iextstr_local + i_rank * nExtStrLocal + (g_->IsBoss() ? 0 : nExtStr%N_ranks );
+                                const uint iext = iextstr/nStr_;
+                                const uint istr = iextstr%nStr_;
 
                                 // io object
                                 DistilMatrixIo<HADRONS_DISTIL_IO_TYPE> matrix_io(filenameDmfFn(iext, istr, n_idx.at(Side::left), n_idx.at(Side::right)),
@@ -1062,8 +1069,8 @@ void DmfComputation<FImpl,T,Tio>
                                     STOP_TIMER("IO: file creation");
                                 }
                                 //translate relative/anchored into left/right
-                                unsigned int left_i  = (Side::left==relative_side)  ? iRel : jAnchor;
-                                unsigned int right_j  = (Side::right==relative_side)  ? iRel : jAnchor;
+                                uint left_i  = (Side::left==relative_side)  ? iRel : jAnchor;
+                                uint right_j  = (Side::right==relative_side)  ? iRel : jAnchor;
                                 START_TIMER("IO: write block");
                                 matrix_io.saveBlock(block_relative, iextstr_local, left_i, right_j, dataset_name, t, blockSize_);
                                 STOP_TIMER("IO: write block");
@@ -1074,7 +1081,7 @@ void DmfComputation<FImpl,T,Tio>
 #endif              
                             STOP_TIMER("IO: total");
                             ioTime    += GET_TIMER("IO: write block");
-                            unsigned int bytesBlockSize  = static_cast<double>(nExt_*nStr_*rel_block_size*anchor_block_size*sizeof(Tio));
+                            uint bytesBlockSize  = static_cast<double>(nExt_*nStr_*rel_block_size*anchor_block_size*sizeof(Tio));
                             double iospeed = bytesBlockSize/ioTime*1.0e6/1024/1024;
                             LOG(Message)    << "HDF5 IO done " << sizeString(bytesBlockSize) << " in "
                                             << ioTime  << " us (" << iospeed << " MB/s)" << std::endl;
@@ -1097,42 +1104,42 @@ void DmfComputation<FImpl,T,Tio>
           Vector<T>&                                    cBuf,
           std::vector<Gamma::Algebra>                   gamma,
           std::map<Side, DistilVector&>                 dv,
-          std::map<Side, unsigned int>                  n_idx,
+          std::map<Side, uint>                          n_idx,
           std::vector<ComplexField>                     ph,
-          std::map<Side, std::vector<unsigned int>>     time_dil_source,
+          std::map<Side, std::vector<uint>>             time_dil_source,
           LapPack&                                      epack,
           TimerArray*                                   tarray,
           bool                                          only_diag,
-          const unsigned int                            diag_shift,
-          std::map<Side, MDistil::PerambTensor&>                 peramb)
+          const uint                                    diag_shift,
+          std::map<Side, MDistil::PerambTensor&>        peramb)
 {
-    const unsigned int vol = g_->_gsites;
+    const uint vol = g_->_gsites;
     //parallel IO info
-    const unsigned int i_rank = g_->ThisRank();
-    const unsigned int N_ranks = g_->RankCount();
-    const unsigned int nExtStr = nExt_*nStr_;
-    const unsigned int nExtStrLocal = g_->IsBoss() ? nExtStr/N_ranks 
+    const uint i_rank = g_->ThisRank();
+    const uint N_ranks = g_->RankCount();
+    const uint nExtStr = nExt_*nStr_;
+    const uint nExtStrLocal = g_->IsBoss() ? nExtStr/N_ranks 
                                         + nExtStr%N_ranks : nExtStr/N_ranks; // put remainder in boss node
 
     //loop over left dv batches
-    for (unsigned int ibatchL=0 ; ibatchL<time_dil_source.at(Side::left).size()/dvBatchSize_ ; ibatchL++)   //loop over left dv batches
+    for (uint ibatchL=0 ; ibatchL<time_dil_source.at(Side::left).size()/dvBatchSize_ ; ibatchL++)   //loop over left dv batches
     {
         LOG(Message) << "Computing (or loading) left distil vector:" << std::endl; 
-        std::vector<unsigned int> batch_dtL = fetchDvBatchIdxs(ibatchL,time_dil_source.at(Side::left));
+        std::vector<uint> batch_dtL = fetchDvBatchIdxs(ibatchL,time_dil_source.at(Side::left));
         START_TIMER("distil vectors");
         makeDvLapSpinBatch(dv, n_idx, epack, Side::left, batch_dtL, peramb);
         STOP_TIMER("distil vectors");
-        for (unsigned int idtL=0 ; idtL<batch_dtL.size() ; idtL++)
+        for (uint idtL=0 ; idtL<batch_dtL.size() ; idtL++)
         {
-            unsigned int dtL = batch_dtL[idtL];
-            for (unsigned int ibatchR=0 ; ibatchR<time_dil_source.at(Side::right).size()/dvBatchSize_ ; ibatchR++)  //loop over right dv batches
+            uint dtL = batch_dtL[idtL];
+            for (uint ibatchR=0 ; ibatchR<time_dil_source.at(Side::right).size()/dvBatchSize_ ; ibatchR++)  //loop over right dv batches
             {
-                std::vector<unsigned int> batch_dtR = fetchDvBatchIdxs(ibatchR,time_dil_source.at(Side::right), diag_shift);
-                for (unsigned int idtR=0 ; idtR<batch_dtR.size() ; idtR++)
+                std::vector<uint> batch_dtR = fetchDvBatchIdxs(ibatchR,time_dil_source.at(Side::right), diag_shift);
+                for (uint idtR=0 ; idtR<batch_dtR.size() ; idtR++)
                 {
-                    unsigned int dtR = batch_dtR[idtR];
+                    uint dtR = batch_dtR[idtR];
                     // fetch necessary time slices for this time-dilution block
-                    std::map<Side,std::vector<unsigned int>> time_partition = { {Side::left,{}} , {Side::right,{}}};
+                    std::map<Side,std::vector<uint>> time_partition = { {Side::left,{}} , {Side::right,{}}};
                     for(auto s : sides)
                     {
                         if(isPhi(s))
@@ -1146,7 +1153,7 @@ void DmfComputation<FImpl,T,Tio>
                             time_partition.at(s) = distilNoise_.at(s).dilutionPartition(Index::t, s==Side::left ? dtL : dtR);
                         }
                     }
-                    std::vector<unsigned int> ts_intersection;
+                    std::vector<uint> ts_intersection;
                     std::set_intersection(time_partition.at(Side::left).begin(), time_partition.at(Side::left).end(), 
                                         time_partition.at(Side::right).begin(), time_partition.at(Side::right).end(),
                                         std::back_inserter(ts_intersection));
@@ -1157,17 +1164,17 @@ void DmfComputation<FImpl,T,Tio>
                     {
                         LOG(Message) << "------------ time-dilution block " << dtL << "-" << dtR << " ------------------------" << std::endl; 
                         
-                        unsigned int nblocki = dilSizeLS_.at(Side::left)/blockSize_ + (((dilSizeLS_.at(Side::left) % blockSize_) != 0) ? 1 : 0);
-                        unsigned int nblockj = dilSizeLS_.at(Side::right)/blockSize_ + (((dilSizeLS_.at(Side::right) % blockSize_) != 0) ? 1 : 0);
+                        uint nblocki = dilSizeLS_.at(Side::left)/blockSize_ + (((dilSizeLS_.at(Side::left) % blockSize_) != 0) ? 1 : 0);
+                        uint nblockj = dilSizeLS_.at(Side::right)/blockSize_ + (((dilSizeLS_.at(Side::right) % blockSize_) != 0) ? 1 : 0);
 
                         // loop over blocks within the current time-dilution block
-                        for(unsigned int i=0 ; i<dilSizeLS_.at(Side::left) ; i+=blockSize_) //set according to memory size
-                        for(unsigned int j=0 ; j<dilSizeLS_.at(Side::right) ; j+=blockSize_)
+                        for(uint i=0 ; i<dilSizeLS_.at(Side::left) ; i+=blockSize_) //set according to memory size
+                        for(uint j=0 ; j<dilSizeLS_.at(Side::right) ; j+=blockSize_)
                         {
                             double flops=0.0, bytes=0.0, time_kernel=0.0, nodes=g_->NodeCount();
                             // iblock_size is the size of the current block (indexed by i); N_i-i is the size of the possible remainder block
-                            unsigned int iblock_size = MIN(dilSizeLS_.at(Side::left)-i,blockSize_);
-                            unsigned int jblock_size = MIN(dilSizeLS_.at(Side::right)-j,blockSize_);
+                            uint iblock_size = MIN(dilSizeLS_.at(Side::left)-i,blockSize_);
+                            uint jblock_size = MIN(dilSizeLS_.at(Side::right)-j,blockSize_);
                             
                             DistilMatrixSetIo<Tio> block(bBuf.data(), nExtStrLocal , nt_, iblock_size, jblock_size);
 
@@ -1178,23 +1185,23 @@ void DmfComputation<FImpl,T,Tio>
                             << std::endl;
 
                             // loop over cache blocks within the current block
-                            for(unsigned int jj=0 ; jj<jblock_size ; jj+=cacheSize_)
+                            for(uint jj=0 ; jj<jblock_size ; jj+=cacheSize_)
                             {
                                 LOG(Message) << "Computing (or loading) right distil vector block " << j+jj << std::endl;
 
-                                unsigned int dv_idxR = dtR*dilSizeLS_.at(Side::right) +j+jj;
+                                uint dvR_idx_offset = dtR*dilSizeLS_.at(Side::right) +j+jj;
                                 START_TIMER("distil vectors");
-                                makeDvLapSpinCacheBlock(dv.at(Side::right),dv_idxR,n_idx,epack,Side::right,peramb);
+                                makeDvLapSpinCacheBlock(dv,dvR_idx_offset,n_idx,epack,Side::right,peramb);
                                 STOP_TIMER("distil vectors");
 
-                                for(unsigned int ii=0 ; ii<iblock_size ; ii+=cacheSize_)
+                                for(uint ii=0 ; ii<iblock_size ; ii+=cacheSize_)
                                 {
-                                    unsigned int icache_size = MIN(iblock_size-ii,cacheSize_);      
-                                    unsigned int jcache_size = MIN(jblock_size-jj,cacheSize_);
+                                    uint icache_size = MIN(iblock_size-ii,cacheSize_);      
+                                    uint jcache_size = MIN(jblock_size-jj,cacheSize_);
 
                                     DistilMatrixSetCache<T> cache(cBuf.data(), nExt_, nStr_, nt_, icache_size, jcache_size);
                                     
-                                    unsigned int dv_idxL = idtL*dilSizeLS_.at(Side::left) +i+ii;
+                                    uint dv_idxL = idtL*dilSizeLS_.at(Side::left) +i+ii;
                                     
                                     double timer = 0.0;
                                     START_TIMER("kernel");
@@ -1211,15 +1218,15 @@ void DmfComputation<FImpl,T,Tio>
                                     // copy cache to ioblock
                                     g_->Barrier();
                                     START_TIMER("cache copy");
-                                    unsigned int ts_size = ts_intersection.size();
+                                    uint ts_size = ts_intersection.size();
                                     thread_for_collapse(4,iextstr_local,nExtStrLocal,{
-                                    for(unsigned int it=0;it<ts_size;it++)
-                                    for(unsigned int iii=0;iii<icache_size;iii++)
-                                    for(unsigned int jjj=0;jjj<jcache_size;jjj++)
+                                    for(uint it=0;it<ts_size;it++)
+                                    for(uint iii=0;iii<icache_size;iii++)
+                                    for(uint jjj=0;jjj<jcache_size;jjj++)
                                     {
-                                        const unsigned int iextstr = iextstr_local + i_rank * nExtStrLocal + (g_->IsBoss() ? 0 : nExtStr%N_ranks );
-                                        const unsigned int iext = iextstr/nStr_;
-                                        const unsigned int istr = iextstr%nStr_;
+                                        const uint iextstr = iextstr_local + i_rank * nExtStrLocal + (g_->IsBoss() ? 0 : nExtStr%N_ranks );
+                                        const uint iext = iextstr/nStr_;
+                                        const uint istr = iextstr%nStr_;
                                         block(iextstr_local,ts_intersection[it],ii+iii,jj+jjj) = cache(iext,istr,ts_intersection[it],iii,jjj);
                                     }
                                     });
@@ -1238,12 +1245,12 @@ void DmfComputation<FImpl,T,Tio>
                             // io section
                             LOG(Message) << "Starting parallel IO. Rank count=" << N_ranks << std::endl;
                             LOG(Message) << "Saving time slices : " << MDistil::timeslicesDump(ts_intersection) << std::endl;
-                            for(unsigned int t=0 ; t<nt_ ; t++)
+                            for(uint t=0 ; t<nt_ ; t++)
                             {
                                 // TODO: generalise to dilution
-                                // unsigned int t = ts_intersection[it];
-                                std::vector<unsigned int> left_partition = distilNoise_.at(Side::left).dilutionPartition(Index::t,dtL);
-                                std::vector<unsigned int> right_partition = distilNoise_.at(Side::right).dilutionPartition(Index::t,dtR);
+                                // uint t = ts_intersection[it];
+                                std::vector<uint> left_partition = distilNoise_.at(Side::left).dilutionPartition(Index::t,dtL);
+                                std::vector<uint> right_partition = distilNoise_.at(Side::right).dilutionPartition(Index::t,dtR);
 
                                 if( !( isRho(Side::left) and std::count(left_partition.begin(), left_partition.end(), t)==0  ) 
                                     and !(isRho(Side::right) and std::count(right_partition.begin(), right_partition.end(), t)==0) )
@@ -1257,11 +1264,11 @@ void DmfComputation<FImpl,T,Tio>
                                     START_TIMER("IO: total");
 #ifdef HADRONS_DISTIL_PARALLEL_IO
                                     g_->Barrier();
-                                    for(unsigned int iextstr_local=0 ; iextstr_local<nExtStrLocal ; iextstr_local++)
+                                    for(uint iextstr_local=0 ; iextstr_local<nExtStrLocal ; iextstr_local++)
                                     {
-                                        const unsigned int iextstr = iextstr_local + i_rank * nExtStrLocal + (g_->IsBoss() ? 0 : nExtStr%N_ranks );
-                                        const unsigned int iext = iextstr/nStr_;
-                                        const unsigned int istr = iextstr%nStr_;
+                                        const uint iextstr = iextstr_local + i_rank * nExtStrLocal + (g_->IsBoss() ? 0 : nExtStr%N_ranks );
+                                        const uint iext = iextstr/nStr_;
+                                        const uint istr = iextstr%nStr_;
 
                                         // io object
                                         DistilMatrixIo<HADRONS_DISTIL_IO_TYPE> matrix_io(filenameDmfFn(iext, istr, n_idx.at(Side::left), n_idx.at(Side::right)),
@@ -1291,7 +1298,7 @@ void DmfComputation<FImpl,T,Tio>
 #endif              
                                     STOP_TIMER("IO: total");
                                     ioTime    += GET_TIMER("IO: write block");
-                                    unsigned int bytesBlockSize  = static_cast<double>(nExt_*nStr_*iblock_size*jblock_size*sizeof(Tio));
+                                    uint bytesBlockSize  = static_cast<double>(nExt_*nStr_*iblock_size*jblock_size*sizeof(Tio));
                                     double iospeed = bytesBlockSize/ioTime*1.0e6/1024/1024;
                                     LOG(Message)    << "HDF5 IO done " << sizeString(bytesBlockSize) << " in "
                                                     << ioTime  << " us (" << iospeed << " MB/s)" << std::endl;

--- a/Hadrons/DistilMatrix.hpp
+++ b/Hadrons/DistilMatrix.hpp
@@ -494,7 +494,8 @@ private:
                             const unsigned int               n_idx,
                             const unsigned int               D,
                             const unsigned int               delta_t,
-                            MDistil::PerambTensor&                    peramb,
+                            std::map<Side, MDistil::PerambTensor&>                     peramb,
+                            Side                                     s,
                             LapPack&                         epack,
                             std::string                      vector_stem="");
     void makeRelativeRhoComponent(FermionField&          rho_component,
@@ -679,68 +680,6 @@ void DmfComputation<FImpl,T,Tio>
             else
             {
                 loadPhiComponent(dv.at(s)[iD] , distilNoise_.at(s) , n_idx.at(s) , D , vectorStem_.at(s), epack);
-
-                // // hack to check correctness on vector_solve reading: compute perambulator and smeared phi vector
-                // int nDL = distilNoise_.at(s).dilutionSize(DistillationNoise::Index::l);        
-                // int nDS = distilNoise_.at(s).dilutionSize(DistillationNoise::Index::s);        
-                // int nDT = distilNoise_.at(s).dilutionSize(DistillationNoise::Index::t);
-                // int nNoise = distilNoise_.at(s).size();
-                // const unsigned int nVec = epack.evec.size();
-                // const unsigned int Nt_first = g_->LocalStarts()[nd_ - 1];
-                // const unsigned int Nt_local = g_->LocalDimensions()[nd_ - 1];
-                // ColourVectorField cv4dtmp(g_);
-                // ColourVectorField cv3dtmp(g3d_);
-                // ColourVectorField evec3d(g3d_);
-                // std::vector<ColourVectorField> evec3d_tmp(Nt_local * nVec, g3d_);
-                // std::vector<int> invT = {0};
-                // MDistil::PerambTensor perambulator(nt_, nVec, nDL, nNoise, invT.size(), nDS);
-
-                // // split lapevec in slices
-                // for (int t = Nt_first; t < Nt_first + Nt_local; t++)
-                // {
-                //     for (int ivec = 0; ivec < nVec; ivec++)
-                //     {
-                //         int jvec= ivec + nVec * (t-Nt_first);
-                //         ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Nt_first,Tdir);
-                //         evec3d_tmp[jvec] = evec3d;
-                //     }
-                // }
-
-                // // compute peramb
-                // std::vector<int>::iterator it = std::find(std::begin(invT), std::end(invT), dt);
-                // auto index = distilNoise_.at(s).dilutionCoordinates(D);
-                // int dt = index[DistillationNoise::Index::t];
-                // int dk = index[DistillationNoise::Index::l];
-                // int ds = index[DistillationNoise::Index::s];
-                // int idt = 0; //it - std::begin(invT);
-                // for (int is = 0; is < Ns; is++)
-                // {
-                //     cv4dtmp = peekSpin(dv.at(s)[iD],is);
-                //     for (int t = Nt_first; t < Nt_first + Nt_local; t++)
-                //     {
-                //         ExtractSliceLocal(cv3dtmp,cv4dtmp,0,t-Nt_first,Tdir); 
-                //         for (int ivec = 0; ivec < nVec; ivec++)
-                //         {
-                //             int jvec= ivec + nVec * (t-Nt_first);
-                //             evec3d_ = evec3d_tmp[jvec];
-                //             pokeSpin(perambulator.tensor(t, ivec, dk, n_idx.at(s),idt,ds),static_cast<Complex>(innerProduct(evec3d_, cv3dtmp)),is);
-                //         }
-                //     }
-                // }
-
-                // // compute smeared phi
-                // for (unsigned int t = Nt_first; t < Nt_first + Nt_local; t++)
-                // {
-                //     tmp3d_ = Zero();
-                //     for (unsigned int k = 0; k < nVec; k++)
-                //     {
-                //         ExtractSliceLocal(evec3d_,epack.evec[k],0,t-Nt_first,nd_ - 1);
-                //         tmp3d_ += evec3d_ * perambulator.tensor(t, k, dk, n_idx.at(s), idt, ds);
-                //     }
-                //     InsertSliceLocal(tmp3d_,dv.at(s)[iD],0,t-Nt_first,nd_ - 1);
-                //     // by here dv.at(s)[iD] should now be the smeared source
-                // }
-
             }
         }
         else if(isRho(s))
@@ -771,68 +710,6 @@ void DmfComputation<FImpl,T,Tio>
             else
             {
                 loadPhiComponent(dv_cache[iD] , distilNoise_.at(s) , n_idx.at(s) , D , vectorStem_.at(s), epack);
-
-                // // hack to check correctness on vector_solve reading: compute perambulator and smeared phi vector
-                // int nDL = distilNoise_.at(s).dilutionSize(DistillationNoise::Index::l);        
-                // int nDS = distilNoise_.at(s).dilutionSize(DistillationNoise::Index::s);        
-                // int nDT = distilNoise_.at(s).dilutionSize(DistillationNoise::Index::t);
-                // int nNoise = distilNoise_.at(s).size();
-                // const unsigned int nVec = epack.evec.size();
-                // const unsigned int Nt_first = g_->LocalStarts()[nd_ - 1];
-                // const unsigned int Nt_local = g_->LocalDimensions()[nd_ - 1];
-                // ColourVectorField cv4dtmp(g_);
-                // ColourVectorField cv3dtmp(g3d_);
-                // ColourVectorField evec3d(g3d_);
-                // std::vector<ColourVectorField> evec3d_tmp(Nt_local * nVec, g3d_);
-                // std::vector<int> invT = {0};
-                // MDistil::PerambTensor perambulator(nt_, nVec, nDL, nNoise, invT.size(), nDS);
-
-                // // split lapevec in slices
-                // for (int t = Nt_first; t < Nt_first + Nt_local; t++)
-                // {
-                //     for (int ivec = 0; ivec < nVec; ivec++)
-                //     {
-                //         int jvec= ivec + nVec * (t-Nt_first);
-                //         ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Nt_first,Tdir);
-                //         evec3d_tmp[jvec] = evec3d;
-                //     }
-                // }
-
-                // // compute peramb
-                // auto index = distilNoise_.at(s).dilutionCoordinates(D);
-                // int dt = index[DistillationNoise::Index::t];
-                // int dk = index[DistillationNoise::Index::l];
-                // int ds = index[DistillationNoise::Index::s];
-                // std::vector<int>::iterator it = std::find(std::begin(invT), std::end(invT), dt);
-                // int idt = 0; //it - std::begin(invT);
-                // for (int is = 0; is < Ns; is++)
-                // {
-                //     cv4dtmp = peekSpin(dv_cache[iD],is);
-                //     for (int t = Nt_first; t < Nt_first + Nt_local; t++)
-                //     {
-                //         ExtractSliceLocal(cv3dtmp,cv4dtmp,0,t-Nt_first,Tdir); 
-                //         for (int ivec = 0; ivec < nVec; ivec++)
-                //         {
-                //             int jvec= ivec + nVec * (t-Nt_first);
-                //             evec3d_ = evec3d_tmp[jvec];
-                //             pokeSpin(perambulator.tensor(t, ivec, dk, n_idx.at(s),idt,ds),static_cast<Complex>(innerProduct(evec3d_, cv3dtmp)),is);
-                //         }
-                //     }
-                // }
-
-                // // compute smeared phi
-                // for (unsigned int t = Nt_first; t < Nt_first + Nt_local; t++)
-                // {
-                //     tmp3d_ = Zero();
-                //     for (unsigned int k = 0; k < nVec; k++)
-                //     {
-                //         ExtractSliceLocal(evec3d_,epack.evec[k],0,t-Nt_first,nd_ - 1);
-                //         tmp3d_ += evec3d_ * perambulator.tensor(t, k, dk, n_idx.at(s), idt, ds);
-                //     }
-                //     InsertSliceLocal(tmp3d_,dv_cache[iD],0,t-Nt_first,nd_ - 1);
-                //     // by here dv_cache.at(s)[iD] should now be the smeared source
-                // }
-
             }
         }
         else if(isRho(s))
@@ -879,7 +756,8 @@ void DmfComputation<FImpl,T,Tio>
                    const unsigned int               n_idx,
                    const unsigned int               D,
                    const unsigned int               delta_t,
-                   MDistil::PerambTensor&                    peramb,
+                   std::map<Side, MDistil::PerambTensor&>            peramb,
+                   Side                             s,
                    LapPack&                         epack,
                    std::string                      vector_stem)
 {
@@ -893,10 +771,7 @@ void DmfComputation<FImpl,T,Tio>
     //compute at relative_time, insert at t=relative_time
     const unsigned int relative_time    = (dt + delta_t)%nt_;               //TODO: generalise to dilution
     const unsigned int t                = relative_time;
-
-    std::vector<int> peramb_ts = peramb.MetaData.timeSources;
-    std::vector<int>::iterator itr_dt = std::find(peramb_ts.begin(), peramb_ts.end(), dt);
-    unsigned int idt_peramb = std::distance(peramb_ts.begin(), itr_dt); //gets correspondent index of dt in the tensor obj 
+     
     const unsigned int nVec = epack.evec.size();
     const unsigned int Nt_first = g_->LocalStarts()[nd_ - 1];
     const unsigned int Nt_local = g_->LocalDimensions()[nd_ - 1];
@@ -907,8 +782,11 @@ void DmfComputation<FImpl,T,Tio>
         {
             if(vector_stem.empty())
             {
+                std::vector<int> peramb_ts = peramb.at(s).MetaData.timeSources;
+                std::vector<int>::iterator itr_dt = std::find(peramb_ts.begin(), peramb_ts.end(), dt);
+                unsigned int idt_peramb = std::distance(peramb_ts.begin(), itr_dt); //gets correspondent index of dt in the tensor obj 
                 ExtractSliceLocal(evec3d_,epack.evec[k],0,relative_time-Nt_first,nd_ - 1);
-                tmp3d_ += evec3d_ * peramb.tensor(relative_time, k, dk, n_idx, idt_peramb, ds);
+                tmp3d_ += evec3d_ * peramb.at(s).tensor(relative_time, k, dk, n_idx, idt_peramb, ds);
             }
             else
             {
@@ -981,7 +859,7 @@ void DmfComputation<FImpl,T,Tio>
             const unsigned int Drelative = distilNoise_.at(s).dilutionIndex(0,dk,ds);
             if(isPhi(s))
             {
-                makeRelativePhiComponent(dv.at(s)[Drelative] , distilNoise_.at(s) , n_idx.at(s) , D , delta_t , peramb.at(s), epack, vectorStem_.at(s));
+                makeRelativePhiComponent(dv.at(s)[Drelative] , distilNoise_.at(s) , n_idx.at(s) , D , delta_t , peramb, s, epack, vectorStem_.at(s));
             }
             else if(isRho(s))
             {
@@ -1228,204 +1106,204 @@ void DmfComputation<FImpl,T,Tio>
           const unsigned int                            diag_shift,
           std::map<Side, MDistil::PerambTensor&>                 peramb)
 {
-//     const unsigned int vol = g_->_gsites;
-//     //parallel IO info
-//     const unsigned int i_rank = g_->ThisRank();
-//     const unsigned int N_ranks = g_->RankCount();
-//     const unsigned int nExtStr = nExt_*nStr_;
-//     const unsigned int nExtStrLocal = g_->IsBoss() ? nExtStr/N_ranks 
-//                                         + nExtStr%N_ranks : nExtStr/N_ranks; // put remainder in boss node
+    const unsigned int vol = g_->_gsites;
+    //parallel IO info
+    const unsigned int i_rank = g_->ThisRank();
+    const unsigned int N_ranks = g_->RankCount();
+    const unsigned int nExtStr = nExt_*nStr_;
+    const unsigned int nExtStrLocal = g_->IsBoss() ? nExtStr/N_ranks 
+                                        + nExtStr%N_ranks : nExtStr/N_ranks; // put remainder in boss node
 
-//     //loop over left dv batches
-//     for (unsigned int ibatchL=0 ; ibatchL<time_dil_source.at(Side::left).size()/dvBatchSize_ ; ibatchL++)   //loop over left dv batches
-//     {
-//         LOG(Message) << "Computing (or loading) left distil vector:" << std::endl; 
-//         std::vector<unsigned int> batch_dtL = fetchDvBatchIdxs(ibatchL,time_dil_source.at(Side::left));
-//         START_TIMER("distil vectors");
-//         makeDvLapSpinBatch(dv, n_idx, epack, Side::left, batch_dtL, peramb);
-//         STOP_TIMER("distil vectors");
-//         for (unsigned int idtL=0 ; idtL<batch_dtL.size() ; idtL++)
-//         {
-//             unsigned int dtL = batch_dtL[idtL];
-//             for (unsigned int ibatchR=0 ; ibatchR<time_dil_source.at(Side::right).size()/dvBatchSize_ ; ibatchR++)  //loop over right dv batches
-//             {
-//                 std::vector<unsigned int> batch_dtR = fetchDvBatchIdxs(ibatchR,time_dil_source.at(Side::right), diag_shift);
-//                 for (unsigned int idtR=0 ; idtR<batch_dtR.size() ; idtR++)
-//                 {
-//                     unsigned int dtR = batch_dtR[idtR];
-//                     // fetch necessary time slices for this time-dilution block
-//                     std::map<Side,std::vector<unsigned int>> time_partition = { {Side::left,{}} , {Side::right,{}}};
-//                     for(auto s : sides)
-//                     {
-//                         if(isPhi(s))
-//                         {
-//                             time_partition.at(s).resize(nt_);
-//                             //phi: fill with all time slices so the intersection with a vector X is equal to X
-//                             std::iota(std::begin(time_partition.at(s)), std::end(time_partition.at(s)), 0); 
-//                         }
-//                         else
-//                         {
-//                             time_partition.at(s) = distilNoise_.at(s).dilutionPartition(Index::t, s==Side::left ? dtL : dtR);
-//                         }
-//                     }
-//                     std::vector<unsigned int> ts_intersection;
-//                     std::set_intersection(time_partition.at(Side::left).begin(), time_partition.at(Side::left).end(), 
-//                                         time_partition.at(Side::right).begin(), time_partition.at(Side::right).end(),
-//                                         std::back_inserter(ts_intersection));
+    //loop over left dv batches
+    for (unsigned int ibatchL=0 ; ibatchL<time_dil_source.at(Side::left).size()/dvBatchSize_ ; ibatchL++)   //loop over left dv batches
+    {
+        LOG(Message) << "Computing (or loading) left distil vector:" << std::endl; 
+        std::vector<unsigned int> batch_dtL = fetchDvBatchIdxs(ibatchL,time_dil_source.at(Side::left));
+        START_TIMER("distil vectors");
+        makeDvLapSpinBatch(dv, n_idx, epack, Side::left, batch_dtL, peramb);
+        STOP_TIMER("distil vectors");
+        for (unsigned int idtL=0 ; idtL<batch_dtL.size() ; idtL++)
+        {
+            unsigned int dtL = batch_dtL[idtL];
+            for (unsigned int ibatchR=0 ; ibatchR<time_dil_source.at(Side::right).size()/dvBatchSize_ ; ibatchR++)  //loop over right dv batches
+            {
+                std::vector<unsigned int> batch_dtR = fetchDvBatchIdxs(ibatchR,time_dil_source.at(Side::right), diag_shift);
+                for (unsigned int idtR=0 ; idtR<batch_dtR.size() ; idtR++)
+                {
+                    unsigned int dtR = batch_dtR[idtR];
+                    // fetch necessary time slices for this time-dilution block
+                    std::map<Side,std::vector<unsigned int>> time_partition = { {Side::left,{}} , {Side::right,{}}};
+                    for(auto s : sides)
+                    {
+                        if(isPhi(s))
+                        {
+                            time_partition.at(s).resize(nt_);
+                            //phi: fill with all time slices so the intersection with a vector X is equal to X
+                            std::iota(std::begin(time_partition.at(s)), std::end(time_partition.at(s)), 0); 
+                        }
+                        else
+                        {
+                            time_partition.at(s) = distilNoise_.at(s).dilutionPartition(Index::t, s==Side::left ? dtL : dtR);
+                        }
+                    }
+                    std::vector<unsigned int> ts_intersection;
+                    std::set_intersection(time_partition.at(Side::left).begin(), time_partition.at(Side::left).end(), 
+                                        time_partition.at(Side::right).begin(), time_partition.at(Side::right).end(),
+                                        std::back_inserter(ts_intersection));
 
-//                     // only execute when partitions have at least one time slice in common; only computes diagonal (up to diag_shift) when onlydiag true
-//                     if( !ts_intersection.empty() and 
-//                         ( !only_diag or ((dtL+diag_shift)%distilNoise_.at(Side::right).dilutionSize(Index::t)==dtR) ) )
-//                     {
-//                         LOG(Message) << "------------ time-dilution block " << dtL << "-" << dtR << " ------------------------" << std::endl; 
+                    // only execute when partitions have at least one time slice in common; only computes diagonal (up to diag_shift) when onlydiag true
+                    if( !ts_intersection.empty() and 
+                        ( !only_diag or ((dtL+diag_shift)%distilNoise_.at(Side::right).dilutionSize(Index::t)==dtR) ) )
+                    {
+                        LOG(Message) << "------------ time-dilution block " << dtL << "-" << dtR << " ------------------------" << std::endl; 
                         
-//                         unsigned int nblocki = dilSizeLS_.at(Side::left)/blockSize_ + (((dilSizeLS_.at(Side::left) % blockSize_) != 0) ? 1 : 0);
-//                         unsigned int nblockj = dilSizeLS_.at(Side::right)/blockSize_ + (((dilSizeLS_.at(Side::right) % blockSize_) != 0) ? 1 : 0);
+                        unsigned int nblocki = dilSizeLS_.at(Side::left)/blockSize_ + (((dilSizeLS_.at(Side::left) % blockSize_) != 0) ? 1 : 0);
+                        unsigned int nblockj = dilSizeLS_.at(Side::right)/blockSize_ + (((dilSizeLS_.at(Side::right) % blockSize_) != 0) ? 1 : 0);
 
-//                         // loop over blocks within the current time-dilution block
-//                         for(unsigned int i=0 ; i<dilSizeLS_.at(Side::left) ; i+=blockSize_) //set according to memory size
-//                         for(unsigned int j=0 ; j<dilSizeLS_.at(Side::right) ; j+=blockSize_)
-//                         {
-//                             double flops=0.0, bytes=0.0, time_kernel=0.0, nodes=g_->NodeCount();
-//                             // iblock_size is the size of the current block (indexed by i); N_i-i is the size of the possible remainder block
-//                             unsigned int iblock_size = MIN(dilSizeLS_.at(Side::left)-i,blockSize_);
-//                             unsigned int jblock_size = MIN(dilSizeLS_.at(Side::right)-j,blockSize_);
+                        // loop over blocks within the current time-dilution block
+                        for(unsigned int i=0 ; i<dilSizeLS_.at(Side::left) ; i+=blockSize_) //set according to memory size
+                        for(unsigned int j=0 ; j<dilSizeLS_.at(Side::right) ; j+=blockSize_)
+                        {
+                            double flops=0.0, bytes=0.0, time_kernel=0.0, nodes=g_->NodeCount();
+                            // iblock_size is the size of the current block (indexed by i); N_i-i is the size of the possible remainder block
+                            unsigned int iblock_size = MIN(dilSizeLS_.at(Side::left)-i,blockSize_);
+                            unsigned int jblock_size = MIN(dilSizeLS_.at(Side::right)-j,blockSize_);
                             
-//                             DistilMatrixSetIo<Tio> block(bBuf.data(), nExtStrLocal , nt_, iblock_size, jblock_size);
+                            DistilMatrixSetIo<Tio> block(bBuf.data(), nExtStrLocal , nt_, iblock_size, jblock_size);
 
-//                             LOG(Message) << "Distil matrix block " 
-//                             << j/blockSize_ + nblocki*i/blockSize_ + 1 
-//                             << "/" << nblocki*nblockj << " [" << i << " .. " 
-//                             << i+iblock_size-1 << ", " << j << " .. " << j+jblock_size-1 << "]" 
-//                             << std::endl;
+                            LOG(Message) << "Distil matrix block " 
+                            << j/blockSize_ + nblocki*i/blockSize_ + 1 
+                            << "/" << nblocki*nblockj << " [" << i << " .. " 
+                            << i+iblock_size-1 << ", " << j << " .. " << j+jblock_size-1 << "]" 
+                            << std::endl;
 
-//                             // loop over cache blocks within the current block
-//                             for(unsigned int jj=0 ; jj<jblock_size ; jj+=cacheSize_)
-//                             {
-//                                 LOG(Message) << "Computing (or loading) right distil vector block " << j+jj << std::endl;
+                            // loop over cache blocks within the current block
+                            for(unsigned int jj=0 ; jj<jblock_size ; jj+=cacheSize_)
+                            {
+                                LOG(Message) << "Computing (or loading) right distil vector block " << j+jj << std::endl;
 
-//                                 unsigned int dv_idxR = dtR*dilSizeLS_.at(Side::right) +j+jj;
-//                                 START_TIMER("distil vectors");
-//                                 makeDvLapSpinCacheBlock(dv.at(Side::right),dv_idxR,n_idx,epack,Side::right,peramb);
-//                                 STOP_TIMER("distil vectors");
+                                unsigned int dv_idxR = dtR*dilSizeLS_.at(Side::right) +j+jj;
+                                START_TIMER("distil vectors");
+                                makeDvLapSpinCacheBlock(dv.at(Side::right),dv_idxR,n_idx,epack,Side::right,peramb);
+                                STOP_TIMER("distil vectors");
 
-//                                 for(unsigned int ii=0 ; ii<iblock_size ; ii+=cacheSize_)
-//                                 {
-//                                     unsigned int icache_size = MIN(iblock_size-ii,cacheSize_);      
-//                                     unsigned int jcache_size = MIN(jblock_size-jj,cacheSize_);
+                                for(unsigned int ii=0 ; ii<iblock_size ; ii+=cacheSize_)
+                                {
+                                    unsigned int icache_size = MIN(iblock_size-ii,cacheSize_);      
+                                    unsigned int jcache_size = MIN(jblock_size-jj,cacheSize_);
 
-//                                     DistilMatrixSetCache<T> cache(cBuf.data(), nExt_, nStr_, nt_, icache_size, jcache_size);
+                                    DistilMatrixSetCache<T> cache(cBuf.data(), nExt_, nStr_, nt_, icache_size, jcache_size);
                                     
-//                                     unsigned int dv_idxL = idtL*dilSizeLS_.at(Side::left) +i+ii;
+                                    unsigned int dv_idxL = idtL*dilSizeLS_.at(Side::left) +i+ii;
                                     
-//                                     double timer = 0.0;
-//                                     START_TIMER("kernel");
-//                                     // multinode operation saving answer to cBuf
-//                                     A2Autils<FImpl>::MesonField(cache, &dv.at(Side::left)[dv_idxL], &dv.at(Side::right)[0], gamma, ph, nd_ - 1, &timer); 
-//                                     STOP_TIMER("kernel");
+                                    double timer = 0.0;
+                                    START_TIMER("kernel");
+                                    // multinode operation saving answer to cBuf
+                                    A2Autils<FImpl>::MesonField(cache, &dv.at(Side::left)[dv_idxL], &dv.at(Side::right)[0], gamma, ph, nd_ - 1, &timer); 
+                                    STOP_TIMER("kernel");
 
-//                                     time_kernel += timer;
+                                    time_kernel += timer;
 
-//                                     flops += vol*(2*8.0+6.0+8.0*nExt_)*icache_size*jcache_size*nStr_;
-//                                     bytes += vol*(12.0*sizeof(T))*icache_size*jcache_size
-//                                             +  vol*(2.0*sizeof(T)*nExt_)*icache_size*jcache_size*nStr_;
+                                    flops += vol*(2*8.0+6.0+8.0*nExt_)*icache_size*jcache_size*nStr_;
+                                    bytes += vol*(12.0*sizeof(T))*icache_size*jcache_size
+                                            +  vol*(2.0*sizeof(T)*nExt_)*icache_size*jcache_size*nStr_;
 
-//                                     // copy cache to ioblock
-//                                     g_->Barrier();
-//                                     START_TIMER("cache copy");
-//                                     unsigned int ts_size = ts_intersection.size();
-//                                     thread_for_collapse(4,iextstr_local,nExtStrLocal,{
-//                                     for(unsigned int it=0;it<ts_size;it++)
-//                                     for(unsigned int iii=0;iii<icache_size;iii++)
-//                                     for(unsigned int jjj=0;jjj<jcache_size;jjj++)
-//                                     {
-//                                         const unsigned int iextstr = iextstr_local + i_rank * nExtStrLocal + (g_->IsBoss() ? 0 : nExtStr%N_ranks );
-//                                         const unsigned int iext = iextstr/nStr_;
-//                                         const unsigned int istr = iextstr%nStr_;
-//                                         block(iextstr_local,ts_intersection[it],ii+iii,jj+jjj) = cache(iext,istr,ts_intersection[it],iii,jjj);
-//                                     }
-//                                     });
-//                                     STOP_TIMER("cache copy");
-//                                     g_->Barrier();
-//                                 }
-//                             }
-//                             LOG(Message) << "Kernel perf (flops) " << flops/time_kernel/1.0e3/nodes 
-//                                         << " Gflop/s/node " << std::endl;
-//                             LOG(Message) << "Kernel perf (read) " << bytes/time_kernel*1.0e6/1024/1024/1024/nodes
-//                                         << " GB/s/node "  << std::endl;
-//                             blockCounter_++;
-//                             blockFlops_ += flops/time_kernel/1.0e3/nodes ;
-//                             blockBytes_ += bytes/time_kernel*1.0e6/1024/1024/1024/nodes;
+                                    // copy cache to ioblock
+                                    g_->Barrier();
+                                    START_TIMER("cache copy");
+                                    unsigned int ts_size = ts_intersection.size();
+                                    thread_for_collapse(4,iextstr_local,nExtStrLocal,{
+                                    for(unsigned int it=0;it<ts_size;it++)
+                                    for(unsigned int iii=0;iii<icache_size;iii++)
+                                    for(unsigned int jjj=0;jjj<jcache_size;jjj++)
+                                    {
+                                        const unsigned int iextstr = iextstr_local + i_rank * nExtStrLocal + (g_->IsBoss() ? 0 : nExtStr%N_ranks );
+                                        const unsigned int iext = iextstr/nStr_;
+                                        const unsigned int istr = iextstr%nStr_;
+                                        block(iextstr_local,ts_intersection[it],ii+iii,jj+jjj) = cache(iext,istr,ts_intersection[it],iii,jjj);
+                                    }
+                                    });
+                                    STOP_TIMER("cache copy");
+                                    g_->Barrier();
+                                }
+                            }
+                            LOG(Message) << "Kernel perf (flops) " << flops/time_kernel/1.0e3/nodes 
+                                        << " Gflop/s/node " << std::endl;
+                            LOG(Message) << "Kernel perf (read) " << bytes/time_kernel*1.0e6/1024/1024/1024/nodes
+                                        << " GB/s/node "  << std::endl;
+                            blockCounter_++;
+                            blockFlops_ += flops/time_kernel/1.0e3/nodes ;
+                            blockBytes_ += bytes/time_kernel*1.0e6/1024/1024/1024/nodes;
 
-//                             // io section
-//                             LOG(Message) << "Starting parallel IO. Rank count=" << N_ranks << std::endl;
-//                             LOG(Message) << "Saving time slices : " << MDistil::timeslicesDump(ts_intersection) << std::endl;
-//                             for(unsigned int t=0 ; t<nt_ ; t++)
-//                             {
-//                                 // TODO: generalise to dilution
-//                                 // unsigned int t = ts_intersection[it];
-//                                 std::vector<unsigned int> left_partition = distilNoise_.at(Side::left).dilutionPartition(Index::t,dtL);
-//                                 std::vector<unsigned int> right_partition = distilNoise_.at(Side::right).dilutionPartition(Index::t,dtR);
+                            // io section
+                            LOG(Message) << "Starting parallel IO. Rank count=" << N_ranks << std::endl;
+                            LOG(Message) << "Saving time slices : " << MDistil::timeslicesDump(ts_intersection) << std::endl;
+                            for(unsigned int t=0 ; t<nt_ ; t++)
+                            {
+                                // TODO: generalise to dilution
+                                // unsigned int t = ts_intersection[it];
+                                std::vector<unsigned int> left_partition = distilNoise_.at(Side::left).dilutionPartition(Index::t,dtL);
+                                std::vector<unsigned int> right_partition = distilNoise_.at(Side::right).dilutionPartition(Index::t,dtR);
 
-//                                 if( !( isRho(Side::left) and std::count(left_partition.begin(), left_partition.end(), t)==0  ) 
-//                                     and !(isRho(Side::right) and std::count(right_partition.begin(), right_partition.end(), t)==0) )
-//                                 {
-//                                     // use same buffer but map it differently 
-//                                     DistilMatrixSetTimeSliceIo<Tio> block_relative(bBuf.data(), nExtStrLocal , iblock_size, jblock_size); 
-//                                     std::string dataset_name = std::to_string(dtL)+"-"+std::to_string(dtR);
-//                                     LOG(Message)    << "Saving block block " << dataset_name << " , t=" << t << std::endl;
+                                if( !( isRho(Side::left) and std::count(left_partition.begin(), left_partition.end(), t)==0  ) 
+                                    and !(isRho(Side::right) and std::count(right_partition.begin(), right_partition.end(), t)==0) )
+                                {
+                                    // use same buffer but map it differently 
+                                    DistilMatrixSetTimeSliceIo<Tio> block_relative(bBuf.data(), nExtStrLocal , iblock_size, jblock_size); 
+                                    std::string dataset_name = std::to_string(dtL)+"-"+std::to_string(dtR);
+                                    LOG(Message)    << "Saving block block " << dataset_name << " , t=" << t << std::endl;
 
-//                                     double ioTime = -GET_TIMER("IO: write block");
-//                                     START_TIMER("IO: total");
-// #ifdef HADRONS_DISTIL_PARALLEL_IO
-//                                     g_->Barrier();
-//                                     for(unsigned int iextstr_local=0 ; iextstr_local<nExtStrLocal ; iextstr_local++)
-//                                     {
-//                                         const unsigned int iextstr = iextstr_local + i_rank * nExtStrLocal + (g_->IsBoss() ? 0 : nExtStr%N_ranks );
-//                                         const unsigned int iext = iextstr/nStr_;
-//                                         const unsigned int istr = iextstr%nStr_;
+                                    double ioTime = -GET_TIMER("IO: write block");
+                                    START_TIMER("IO: total");
+#ifdef HADRONS_DISTIL_PARALLEL_IO
+                                    g_->Barrier();
+                                    for(unsigned int iextstr_local=0 ; iextstr_local<nExtStrLocal ; iextstr_local++)
+                                    {
+                                        const unsigned int iextstr = iextstr_local + i_rank * nExtStrLocal + (g_->IsBoss() ? 0 : nExtStr%N_ranks );
+                                        const unsigned int iext = iextstr/nStr_;
+                                        const unsigned int istr = iextstr%nStr_;
 
-//                                         // io object
-//                                         DistilMatrixIo<HADRONS_DISTIL_IO_TYPE> matrix_io(filenameDmfFn(iext, istr, n_idx.at(Side::left), n_idx.at(Side::right)),
-//                                                 DISTIL_MATRIX_NAME, nt_, dilSizeLS_.at(Side::left), dilSizeLS_.at(Side::right));
+                                        // io object
+                                        DistilMatrixIo<HADRONS_DISTIL_IO_TYPE> matrix_io(filenameDmfFn(iext, istr, n_idx.at(Side::left), n_idx.at(Side::right)),
+                                                DISTIL_MATRIX_NAME, nt_, dilSizeLS_.at(Side::left), dilSizeLS_.at(Side::right));
 
-//                                         //executes once per file
-//                                         if( ( dtL==time_dil_source.at(Side::left).front() ) and      //first time-dilution idx at one side
-//                                             ( dtR==((time_dil_source.at(Side::right).front()+diag_shift)%distilNoise_.at(Side::right).dilutionSize(Index::t)) ) and    // same as above for the other side
-//                                             ( t==ts_intersection.front() ) and    //first time slice
-//                                             (i==0) and (j==0) )  //first IO block
-//                                         {
-//                                             // fetch metadata
-//                                             DistilMesonFieldMetadata<FImpl> md = metadataDmfFn(iext,istr,n_idx.at(Side::left),n_idx.at(Side::right),
-//                                                                     fetchDilutionMap(Side::left),fetchDilutionMap(Side::right));
-//                                             //init file and write metadata
-//                                             START_TIMER("IO: file creation");
-//                                             matrix_io.initFile(md);
-//                                             STOP_TIMER("IO: file creation");
-//                                         }
-//                                         START_TIMER("IO: write block");
-//                                         matrix_io.saveBlock(block_relative, iextstr_local, i, j, dataset_name, t, blockSize_);
-//                                         STOP_TIMER("IO: write block");
-//                                     }
-//                                     g_->Barrier();
-// #else
-//     HADRONS_ERROR(Implementation, "DistilMesonField serial IO not implemented.");
-// #endif              
-//                                     STOP_TIMER("IO: total");
-//                                     ioTime    += GET_TIMER("IO: write block");
-//                                     unsigned int bytesBlockSize  = static_cast<double>(nExt_*nStr_*iblock_size*jblock_size*sizeof(Tio));
-//                                     double iospeed = bytesBlockSize/ioTime*1.0e6/1024/1024;
-//                                     LOG(Message)    << "HDF5 IO done " << sizeString(bytesBlockSize) << " in "
-//                                                     << ioTime  << " us (" << iospeed << " MB/s)" << std::endl;
-//                                     blockIoSpeed_ += iospeed;
-//                                 }
-//                             }
-//                         }
-//                     }
-//                 }
-//             }
-//         }
-//     }
+                                        //executes once per file
+                                        if( ( dtL==time_dil_source.at(Side::left).front() ) and      //first time-dilution idx at one side
+                                            ( dtR==((time_dil_source.at(Side::right).front()+diag_shift)%distilNoise_.at(Side::right).dilutionSize(Index::t)) ) and    // same as above for the other side
+                                            ( t==ts_intersection.front() ) and    //first time slice
+                                            (i==0) and (j==0) )  //first IO block
+                                        {
+                                            // fetch metadata
+                                            DistilMesonFieldMetadata<FImpl> md = metadataDmfFn(iext,istr,n_idx.at(Side::left),n_idx.at(Side::right),
+                                                                    fetchDilutionMap(Side::left),fetchDilutionMap(Side::right));
+                                            //init file and write metadata
+                                            START_TIMER("IO: file creation");
+                                            matrix_io.initFile(md);
+                                            STOP_TIMER("IO: file creation");
+                                        }
+                                        START_TIMER("IO: write block");
+                                        matrix_io.saveBlock(block_relative, iextstr_local, i, j, dataset_name, t, blockSize_);
+                                        STOP_TIMER("IO: write block");
+                                    }
+                                    g_->Barrier();
+#else
+    HADRONS_ERROR(Implementation, "DistilMesonField serial IO not implemented.");
+#endif              
+                                    STOP_TIMER("IO: total");
+                                    ioTime    += GET_TIMER("IO: write block");
+                                    unsigned int bytesBlockSize  = static_cast<double>(nExt_*nStr_*iblock_size*jblock_size*sizeof(Tio));
+                                    double iospeed = bytesBlockSize/ioTime*1.0e6/1024/1024;
+                                    LOG(Message)    << "HDF5 IO done " << sizeString(bytesBlockSize) << " in "
+                                                    << ioTime  << " us (" << iospeed << " MB/s)" << std::endl;
+                                    blockIoSpeed_ += iospeed;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 END_HADRONS_NAMESPACE

--- a/Hadrons/DistilMatrix.hpp
+++ b/Hadrons/DistilMatrix.hpp
@@ -618,19 +618,19 @@ void DmfComputation<FImpl,T,Tio>
                 loadPhiComponent(dv.at(s)[iD] , distilNoise_.at(s) , n_idx.at(s) , D , vectorStem_.at(s), epack);
 
                 // // hack to check correctness on vector_solve reading: compute perambulator and smeared phi vector
-                // int nDL = n_idx.at(s).dilutionSize(DistillationNoise::Index::l);        
-                // int nDS = n_idx.at(s).dilutionSize(DistillationNoise::Index::s);        
-                // int nDT = n_idx.at(s).dilutionSize(DistillationNoise::Index::t);
-                // int nNoise = n_idx.at(s).size();
+                // int nDL = distilNoise_.at(s).dilutionSize(DistillationNoise::Index::l);        
+                // int nDS = distilNoise_.at(s).dilutionSize(DistillationNoise::Index::s);        
+                // int nDT = distilNoise_.at(s).dilutionSize(DistillationNoise::Index::t);
+                // int nNoise = distilNoise_.at(s).size();
                 // const unsigned int nVec = epack.evec.size();
                 // const unsigned int Nt_first = g_->LocalStarts()[nd_ - 1];
                 // const unsigned int Nt_local = g_->LocalDimensions()[nd_ - 1];
                 // ColourVectorField cv4dtmp(g_);
                 // ColourVectorField cv3dtmp(g3d_);
                 // ColourVectorField evec3d(g3d_);
-                // std::vector<ColourVectorField> evec3d_tmp(Ntlocal * nVec, g3d_);
-                // std::vector<int> invT = {0,1,2,3,4,5,6,7}; //testing using all time sources
-                // MDistil::PerambTensor perambulator(Nt, nVec, nDL, nNoise, invT.size(), nDS);
+                // std::vector<ColourVectorField> evec3d_tmp(Nt_local * nVec, g3d_);
+                // std::vector<int> invT = {0};
+                // MDistil::PerambTensor perambulator(nt_, nVec, nDL, nNoise, invT.size(), nDS);
 
                 // // split lapevec in slices
                 // for (int t = Nt_first; t < Nt_first + Nt_local; t++)
@@ -645,11 +645,11 @@ void DmfComputation<FImpl,T,Tio>
 
                 // // compute peramb
                 // std::vector<int>::iterator it = std::find(std::begin(invT), std::end(invT), dt);
-                // auto index = n_idx.at(s).dilutionCoordinates(D);
+                // auto index = distilNoise_.at(s).dilutionCoordinates(D);
                 // int dt = index[DistillationNoise::Index::t];
                 // int dk = index[DistillationNoise::Index::l];
                 // int ds = index[DistillationNoise::Index::s];
-                // int idt=it - std::begin(invT);
+                // int idt = 0; //it - std::begin(invT);
                 // for (int is = 0; is < Ns; is++)
                 // {
                 //     cv4dtmp = peekSpin(dv.at(s)[iD],is);
@@ -660,7 +660,7 @@ void DmfComputation<FImpl,T,Tio>
                 //         {
                 //             int jvec= ivec + nVec * (t-Nt_first);
                 //             evec3d_ = evec3d_tmp[jvec];
-                //             pokeSpin(perambulator.tensor(t, ivec, dk, n_idx,idt,ds),static_cast<Complex>(innerProduct(evec3d_, cv3dtmp)),is);
+                //             pokeSpin(perambulator.tensor(t, ivec, dk, n_idx.at(s),idt,ds),static_cast<Complex>(innerProduct(evec3d_, cv3dtmp)),is);
                 //         }
                 //     }
                 // }
@@ -672,7 +672,7 @@ void DmfComputation<FImpl,T,Tio>
                 //     for (unsigned int k = 0; k < nVec; k++)
                 //     {
                 //         ExtractSliceLocal(evec3d_,epack.evec[k],0,t-Nt_first,nd_ - 1);
-                //         tmp3d_ += evec3d_ * perambulator.tensor(t, k, dk, n_idx, idt, ds);
+                //         tmp3d_ += evec3d_ * perambulator.tensor(t, k, dk, n_idx.at(s), idt, ds);
                 //     }
                 //     InsertSliceLocal(tmp3d_,dv.at(s)[iD],0,t-Nt_first,nd_ - 1);
                 //     // by here dv.at(s)[iD] should now be the smeared source
@@ -708,6 +708,68 @@ void DmfComputation<FImpl,T,Tio>
             else
             {
                 loadPhiComponent(dv_cache[iD] , distilNoise_.at(s) , n_idx.at(s) , D , vectorStem_.at(s), epack);
+
+                // // hack to check correctness on vector_solve reading: compute perambulator and smeared phi vector
+                // int nDL = distilNoise_.at(s).dilutionSize(DistillationNoise::Index::l);        
+                // int nDS = distilNoise_.at(s).dilutionSize(DistillationNoise::Index::s);        
+                // int nDT = distilNoise_.at(s).dilutionSize(DistillationNoise::Index::t);
+                // int nNoise = distilNoise_.at(s).size();
+                // const unsigned int nVec = epack.evec.size();
+                // const unsigned int Nt_first = g_->LocalStarts()[nd_ - 1];
+                // const unsigned int Nt_local = g_->LocalDimensions()[nd_ - 1];
+                // ColourVectorField cv4dtmp(g_);
+                // ColourVectorField cv3dtmp(g3d_);
+                // ColourVectorField evec3d(g3d_);
+                // std::vector<ColourVectorField> evec3d_tmp(Nt_local * nVec, g3d_);
+                // std::vector<int> invT = {0};
+                // MDistil::PerambTensor perambulator(nt_, nVec, nDL, nNoise, invT.size(), nDS);
+
+                // // split lapevec in slices
+                // for (int t = Nt_first; t < Nt_first + Nt_local; t++)
+                // {
+                //     for (int ivec = 0; ivec < nVec; ivec++)
+                //     {
+                //         int jvec= ivec + nVec * (t-Nt_first);
+                //         ExtractSliceLocal(evec3d,epack.evec[ivec],0,t-Nt_first,Tdir);
+                //         evec3d_tmp[jvec] = evec3d;
+                //     }
+                // }
+
+                // // compute peramb
+                // auto index = distilNoise_.at(s).dilutionCoordinates(D);
+                // int dt = index[DistillationNoise::Index::t];
+                // int dk = index[DistillationNoise::Index::l];
+                // int ds = index[DistillationNoise::Index::s];
+                // std::vector<int>::iterator it = std::find(std::begin(invT), std::end(invT), dt);
+                // int idt = 0; //it - std::begin(invT);
+                // for (int is = 0; is < Ns; is++)
+                // {
+                //     cv4dtmp = peekSpin(dv_cache[iD],is);
+                //     for (int t = Nt_first; t < Nt_first + Nt_local; t++)
+                //     {
+                //         ExtractSliceLocal(cv3dtmp,cv4dtmp,0,t-Nt_first,Tdir); 
+                //         for (int ivec = 0; ivec < nVec; ivec++)
+                //         {
+                //             int jvec= ivec + nVec * (t-Nt_first);
+                //             evec3d_ = evec3d_tmp[jvec];
+                //             pokeSpin(perambulator.tensor(t, ivec, dk, n_idx.at(s),idt,ds),static_cast<Complex>(innerProduct(evec3d_, cv3dtmp)),is);
+                //         }
+                //     }
+                // }
+
+                // // compute smeared phi
+                // for (unsigned int t = Nt_first; t < Nt_first + Nt_local; t++)
+                // {
+                //     tmp3d_ = Zero();
+                //     for (unsigned int k = 0; k < nVec; k++)
+                //     {
+                //         ExtractSliceLocal(evec3d_,epack.evec[k],0,t-Nt_first,nd_ - 1);
+                //         tmp3d_ += evec3d_ * perambulator.tensor(t, k, dk, n_idx.at(s), idt, ds);
+                //     }
+                //     InsertSliceLocal(tmp3d_,dv_cache[iD],0,t-Nt_first,nd_ - 1);
+                //     // by here dv_cache.at(s)[iD] should now be the smeared source
+                // }
+
             }
         }
         else if(isRho(s))

--- a/Hadrons/Modules/MDistil/DistilMesonFieldFixed.hpp
+++ b/Hadrons/Modules/MDistil/DistilMesonFieldFixed.hpp
@@ -253,9 +253,9 @@ void TDistilMesonFieldFixed<FImpl>::setup(void)
     //envTmp(DistilVector,                "dvr",          1, DISTILVECTOR_TIME_cBATCH_SIZE*dilSizeLS_.at(Side::right), g);
     envTmp(DistilVector,                "dvr",          1, par().cacheSize, g);
     unsigned int nnode = g->RankCount();
-    unsigned int nExtLocal = g->IsBoss() ? nExt/nnode + nExt%nnode : nExt/nnode; // put remainder in boss node
-    unsigned int nStrLocal = g->IsBoss() ? nStr/nnode + nStr%nnode : nStr/nnode;
-    envTmp(Vector<HADRONS_DISTIL_IO_TYPE>, "block_buf", 1, nt * nExtLocal * nStrLocal * par().blockSize * par().blockSize);
+    const unsigned int nExtStr = nExt*nStr;
+    const unsigned int nExtStrLocal = g->IsBoss() ? nExtStr/nnode + nExtStr%nnode : nExtStr/nnode; // put remainder in boss node
+    envTmp(Vector<HADRONS_DISTIL_IO_TYPE>, "block_buf", 1, nt * nExtStrLocal * par().blockSize * par().blockSize);
     envTmp(Vector<HADRONS_DISTIL_TYPE>,    "cache_buf", 1, nt * nExt * nStr * par().cacheSize * par().cacheSize);
     envTmp(Computation,                 "computation",  1, dmfType_, g, g3d, noisel, noiser, par().blockSize, 
                 par().cacheSize, env().getDim(g->Nd() - 1), momenta_.size(), gamma_.size(), isExact_, vm().getTrajectory(), par().leftVectorStem, par().rightVectorStem);

--- a/Hadrons/Modules/MDistil/DistilMesonFieldFixed.hpp
+++ b/Hadrons/Modules/MDistil/DistilMesonFieldFixed.hpp
@@ -252,7 +252,10 @@ void TDistilMesonFieldFixed<FImpl>::setup(void)
     //envTmp(DistilVector,                "dvl",          1, par().cacheSize, g);
     //envTmp(DistilVector,                "dvr",          1, DISTILVECTOR_TIME_cBATCH_SIZE*dilSizeLS_.at(Side::right), g);
     envTmp(DistilVector,                "dvr",          1, par().cacheSize, g);
-    envTmp(Vector<HADRONS_DISTIL_IO_TYPE>, "block_buf", 1, nt * nExt * nStr * par().blockSize * par().blockSize);
+    unsigned int nnode = g->RankCount();
+    unsigned int nExtLocal = g->IsBoss() ? nExt/nnode + nExt%nnode : nExt/nnode; // put remainder in boss node
+    unsigned int nStrLocal = g->IsBoss() ? nStr/nnode + nStr%nnode : nStr/nnode;
+    envTmp(Vector<HADRONS_DISTIL_IO_TYPE>, "block_buf", 1, nt * nExtLocal * nStrLocal * par().blockSize * par().blockSize);
     envTmp(Vector<HADRONS_DISTIL_TYPE>,    "cache_buf", 1, nt * nExt * nStr * par().cacheSize * par().cacheSize);
     envTmp(Computation,                 "computation",  1, dmfType_, g, g3d, noisel, noiser, par().blockSize, 
                 par().cacheSize, env().getDim(g->Nd() - 1), momenta_.size(), gamma_.size(), isExact_, vm().getTrajectory(), par().leftVectorStem, par().rightVectorStem);

--- a/Hadrons/Modules/MDistil/DistilMesonFieldFixed.hpp
+++ b/Hadrons/Modules/MDistil/DistilMesonFieldFixed.hpp
@@ -248,8 +248,8 @@ void TDistilMesonFieldFixed<FImpl>::setup(void)
     unsigned int nExt = momenta_.size() , nStr = gamma_.size();
     envTmpLat(ComplexField,             "coor");
     envTmp(std::vector<ComplexField>,   "phase",        1, nExt, g );
-    envTmp(DistilVector,                "dvl",          1, DISTILVECTOR_TIME_BATCH_SIZE*dilSizeLS_.at(Side::left), g);
-    //envTmp(DistilVector,                "dvl",          1, par().cacheSize, g);
+    // envTmp(DistilVector,                "dvl",          1, DISTILVECTOR_TIME_BATCH_SIZE*dilSizeLS_.at(Side::left), g);
+    envTmp(DistilVector,                "dvl",          1, par().cacheSize, g);
     //envTmp(DistilVector,                "dvr",          1, DISTILVECTOR_TIME_cBATCH_SIZE*dilSizeLS_.at(Side::right), g);
     envTmp(DistilVector,                "dvr",          1, par().cacheSize, g);
     unsigned int nnode = g->RankCount();

--- a/Hadrons/Modules/MDistil/DistilMesonFieldFixed.hpp
+++ b/Hadrons/Modules/MDistil/DistilMesonFieldFixed.hpp
@@ -247,9 +247,10 @@ void TDistilMesonFieldFixed<FImpl>::setup(void)
 
     envTmpLat(ComplexField,             "coor");
     envTmp(std::vector<ComplexField>,   "phase",        1, momenta_.size(), g );
-    //envTmp(DistilVector,                "dvl",          1, DISTILVECTOR_TIME_BATCH_SIZE*dilSizeLS_.at(Side::left), g);
-    envTmp(DistilVector,                "dvl",          1, par().cacheSize, g);
-    envTmp(DistilVector,                "dvr",          1, DISTILVECTOR_TIME_BATCH_SIZE*dilSizeLS_.at(Side::right), g);
+    envTmp(DistilVector,                "dvl",          1, DISTILVECTOR_TIME_BATCH_SIZE*dilSizeLS_.at(Side::left), g);
+    //envTmp(DistilVector,                "dvl",          1, par().cacheSize, g);
+    //envTmp(DistilVector,                "dvr",          1, DISTILVECTOR_TIME_BATCH_SIZE*dilSizeLS_.at(Side::right), g);
+    envTmp(DistilVector,                "dvr",          1, par().cacheSize, g);
     envTmp(Computation,                 "computation",  1, dmfType_, g, g3d, noisel, noiser, par().blockSize, 
                 par().cacheSize, env().getDim(g->Nd() - 1), momenta_.size(), gamma_.size(), isExact_, vm().getTrajectory(), par().leftVectorStem, par().rightVectorStem);
 }

--- a/Hadrons/Modules/MDistil/DistilMesonFieldFixed.hpp
+++ b/Hadrons/Modules/MDistil/DistilMesonFieldFixed.hpp
@@ -247,7 +247,8 @@ void TDistilMesonFieldFixed<FImpl>::setup(void)
 
     envTmpLat(ComplexField,             "coor");
     envTmp(std::vector<ComplexField>,   "phase",        1, momenta_.size(), g );
-    envTmp(DistilVector,                "dvl",          1, DISTILVECTOR_TIME_BATCH_SIZE*dilSizeLS_.at(Side::left), g);
+    //envTmp(DistilVector,                "dvl",          1, DISTILVECTOR_TIME_BATCH_SIZE*dilSizeLS_.at(Side::left), g);
+    envTmp(DistilVector,                "dvl",          1, par().cacheSize, g);
     envTmp(DistilVector,                "dvr",          1, DISTILVECTOR_TIME_BATCH_SIZE*dilSizeLS_.at(Side::right), g);
     envTmp(Computation,                 "computation",  1, dmfType_, g, g3d, noisel, noiser, par().blockSize, 
                 par().cacheSize, env().getDim(g->Nd() - 1), momenta_.size(), gamma_.size(), isExact_, vm().getTrajectory(), par().leftVectorStem, par().rightVectorStem);

--- a/Hadrons/Modules/MDistil/DistilMesonFieldRelative.hpp
+++ b/Hadrons/Modules/MDistil/DistilMesonFieldRelative.hpp
@@ -278,7 +278,10 @@ void TDistilMesonFieldRelative<FImpl>::setup(void)
     envTmp(std::vector<ComplexField>,   "phase",        1, nExt, g );
     envTmp(DistilVector,                "dvl",          1, dilSizeT.at(Side::left)*dilSizeLS_.at(Side::left), g);
     envTmp(DistilVector,                "dvr",          1, dilSizeT.at(Side::right)*dilSizeLS_.at(Side::right), g);
-    envTmp(Vector<HADRONS_DISTIL_IO_TYPE>, "block_buf", 1, nt * nExt * nStr * par().blockSize * par().blockSize);
+     unsigned int nnode = g->RankCount();
+    const unsigned int nExtStr = nExt*nStr;
+    const unsigned int nExtStrLocal = g->IsBoss() ? nExtStr/nnode + nExtStr%nnode : nExtStr/nnode; // put remainder in boss node
+    envTmp(Vector<HADRONS_DISTIL_IO_TYPE>, "block_buf", 1, nt * nExtStrLocal * par().blockSize * par().blockSize);
     envTmp(Vector<HADRONS_DISTIL_TYPE>,    "cache_buf", 1, nt * nExt * nStr * par().cacheSize * par().cacheSize);
     envTmp(Computation,                 "computation",  1, dmfType_, g, g3d, noisel, noiser, par().blockSize, 
                 par().cacheSize, env().getDim(g->Nd() - 1), momenta_.size(), gamma_.size(), isExact_, vm().getTrajectory(), par().leftVectorStem, par().rightVectorStem);

--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -249,6 +249,7 @@ void TPerambulator<FImpl>::execute(void)
 
     pMode perambMode{par().perambMode};
     LOG(Message)<< "Mode " << perambMode << std::endl;
+    LOG(Message)<< "Source batch size = " << par().sourceBatchSize << std::endl;
 
     envGetTmp(FermionField,      fermion3dtmp);
     envGetTmp(ColourVectorField, cv4dtmp);

--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -489,6 +489,8 @@ void TPerambulator<FImpl>::execute(void)
             LOG(Message) <<  "saving perambulator dt= " << dt << std::endl;
             idt=it - std::begin(invT);
             std::string sPerambName {par().perambOutFileName};
+            sPerambName.append(".");
+            sPerambName.append(std::to_string(vm().getTrajectory()));
             sPerambName.append("/iDT_");
             sPerambName.append(std::to_string(dt));
             sPerambName.append(".");

--- a/Hadrons/Modules/MDistil/Perambulator.hpp
+++ b/Hadrons/Modules/MDistil/Perambulator.hpp
@@ -50,7 +50,7 @@ BEGIN_MODULE_NAMESPACE(MDistil)
  *                             Perambulator                                    *
  ******************************************************************************/
 
-GRID_SERIALIZABLE_ENUM(pMode, undef, perambOnly, 0, inputSolve, 1, outputSolve, 2, saveSolve, 3);
+GRID_SERIALIZABLE_ENUM(pMode, undef, perambOnly, 0, inputSolve, 1, outputSolve, 2, saveSolveOnly, 3);
 
 class PerambulatorPar: Serializable
 {
@@ -59,9 +59,9 @@ public:
                                     std::string, lapEigenPack,
                                     std::string, solver,
                                     int,         sourceBatchSize,
-                                    std::string, perambFileName,
-                                    std::string, fullSolveFileName,
-                                    std::string, fullSolve,
+                                    std::string, perambOutFileName,
+                                    std::string, unsmSolveOutFileName,
+                                    std::string, unsmSolve,
                                     std::string, distilNoise,
                                     std::string, timeSources,
                                     pMode, perambMode,
@@ -107,7 +107,7 @@ std::vector<std::string> TPerambulator<FImpl>::getInput(void)
     pMode perambMode{par().perambMode};
     if(perambMode == pMode::inputSolve)
     {
-        in.push_back(par().fullSolve);
+        in.push_back(par().unsmSolve);
     }
     else
     {
@@ -124,7 +124,7 @@ std::vector<std::string> TPerambulator<FImpl>::getOutput(void)
     pMode perambMode{par().perambMode};
     if(perambMode == pMode::outputSolve)
     {
-        out.push_back( getName()+"_full_solve" );
+        out.push_back( getName()+"_unsm_solve" );
     }
     return out;
 }
@@ -143,7 +143,7 @@ void TPerambulator<FImpl>::setup(void)
     int nDT = dilNoise.dilutionSize(DistillationNoise<FImpl>::Index::t);
     pMode perambMode{par().perambMode};
     // get nVec from DilutedNoise class, unless specified here. This is useful (and allowed) only in the inputSolve mode, 
-    // where an already computed full solve can be recycled to compute a new perambulator with a smaller nVec.   
+    // where an already computed unsm solve can be recycled to compute a new perambulator with a smaller nVec.   
     int nVec=0;
     if(par().nVec.empty())
     {
@@ -162,7 +162,7 @@ void TPerambulator<FImpl>::setup(void)
         HADRONS_ERROR(Argument, "only perambMode = inputSolve supports a different nVec to the one specified in DilutedNoise");
     }
     // If we run with reduced nVec we still need the same DilutedNoise object, we have to keep track of two different values of nDL:
-    // the one used for the original full solve, and the one used in this module execution 
+    // the one used for the original unsm solve, and the one used in this module execution 
     int nDL_reduced=nDL;
     if(nDL>nVec)
     {
@@ -189,9 +189,17 @@ void TPerambulator<FImpl>::setup(void)
     envTmp(PerambIndexTensor, "PerambDT",1,Nt,nVec,nDL_reduced,nNoise,nDS);
     if(perambMode == pMode::outputSolve)
     {
-        LOG(Message)<< "setting up output field for full solves" << std::endl;
-        envCreate(std::vector<FermionField>, getName()+"_full_solve", 1, nNoise*nDL*nDS*nSourceT,
+        LOG(Message)<< "setting up output field for unsm solves to " << getName()+"_unsm_solve" << std::endl;
+        if(!par().unsmSolveOutFileName.empty())
+        {
+            LOG(Message)<< "also saving solves to stem '" << par().unsmSolveOutFileName << "'" << std::endl;
+        }
+        envCreate(std::vector<FermionField>, getName()+"_unsm_solve", 1, nNoise*nDL*nDS*nSourceT,
         envGetGrid(FermionField));
+    }
+    else if(perambMode == pMode::inputSolve)
+    {
+        LOG(Message)<< "setting up input solve from diluted noise '" << par().distilNoise << "' and reduced nVec=" << par().nVec <<  std::endl;
     }
 
     envTmp(FermionField,         "fermion3dtmp", 1, grid3d);
@@ -303,7 +311,7 @@ void TPerambulator<FImpl>::execute(void)
             if(perambMode == pMode::inputSolve)
             {
                 START_P_TIMER("input solve");
-                auto &solveIn = envGet(std::vector<FermionField>, par().fullSolve);
+                auto &solveIn = envGet(std::vector<FermionField>, par().unsmSolve);
                 // Index of the solve just has the reduced time dimension & uses nDL from solveIn
                 dIndexSolve = ds + nDS * dk + nDL * nDS * idt;
                 fermion4dtmp_vec[iSource] = solveIn[inoise+nNoise*dIndexSolve];
@@ -358,9 +366,9 @@ void TPerambulator<FImpl>::execute(void)
                 }
                 if(perambMode == pMode::outputSolve)
                 {
-                    START_P_TIMER("output solve");
                     for (iSource = 0; iSource < sourceBatchSize; iSource ++)
                     {
+                        START_P_TIMER("output solve");
                         int in = sourceIndices[iSource] % nNoise;
                         int id = sourceIndices[iSource] / nNoise;
                         index = dilNoise.dilutionCoordinates(id);
@@ -371,17 +379,16 @@ void TPerambulator<FImpl>::execute(void)
                         idt=it - std::begin(invT);
                         // Index of the solve just has the reduced time dimension                         
                         dIndexSolve = ds + nDS * dk + nDL * nDS * idt;
-                        auto &solveOut = envGet(std::vector<FermionField>, getName()+"_full_solve");
+                        auto &solveOut = envGet(std::vector<FermionField>, getName()+"_unsm_solve");
                         solveOut[in+nNoise*dIndexSolve] = fermion4dtmp_vec[iSource];                     
+                        STOP_P_TIMER("output solve");
                     }
-                    STOP_P_TIMER("output solve");
                 }
-                if(perambMode == pMode::saveSolve)
+                if(perambMode == pMode::saveSolveOnly or (perambMode == pMode::outputSolve and !par().unsmSolveOutFileName.empty()))
                 {
-                    
-                    START_P_TIMER("save solve");
                     for (iSource = 0; iSource < sourceBatchSize; iSource ++)
                     {
+                        START_P_TIMER("save solve");
                         int in = sourceIndices[iSource] % nNoise;
                         int id = sourceIndices[iSource] / nNoise;
                         index = dilNoise.dilutionCoordinates(id);
@@ -392,12 +399,12 @@ void TPerambulator<FImpl>::execute(void)
                         idt=it - std::begin(invT);
                         // Index of the solve has the full time dimension
                         dIndexSolve = dilNoise.dilutionIndex(dt,dk,ds);
-                        std::string sFileName(par().fullSolveFileName);
+                        std::string sFileName(par().unsmSolveOutFileName);
                         sFileName.append("_noise");
                         sFileName.append(std::to_string(in));
-                        DistillationVectorsIo::writeComponent(sFileName, fermion4dtmp_vec[iSource], "fullSolve", nNoise, nDL, nDS, nDT, invT, in+nNoise*dIndexSolve, vm().getTrajectory());
+                        DistillationVectorsIo::writeComponent(sFileName, fermion4dtmp_vec[iSource], "unsmSolve", nNoise, nDL, nDS, nDT, invT, in+nNoise*dIndexSolve, vm().getTrajectory());
+                        STOP_P_TIMER("save solve");
                     }
-                    STOP_P_TIMER("save solve");
                 }
             }
             START_P_TIMER("perambulator computation");
@@ -463,7 +470,7 @@ void TPerambulator<FImpl>::execute(void)
     }
 
     // Save the perambulator to disk from the boss node
-    if (grid4d->IsBoss() && !par().perambFileName.empty())
+    if (grid4d->IsBoss() && !par().perambOutFileName.empty())
     {
         START_P_TIMER("perambulator io");
         envGetTmp(PerambIndexTensor, PerambDT);
@@ -480,7 +487,7 @@ void TPerambulator<FImpl>::execute(void)
             }
             LOG(Message) <<  "saving perambulator dt= " << dt << std::endl;
             idt=it - std::begin(invT);
-            std::string sPerambName {par().perambFileName};
+            std::string sPerambName {par().perambOutFileName};
             sPerambName.append("/iDT_");
             sPerambName.append(std::to_string(dt));
             sPerambName.append(".");

--- a/Hadrons/Modules/MIO/LoadPerambulator.hpp
+++ b/Hadrons/Modules/MIO/LoadPerambulator.hpp
@@ -145,6 +145,8 @@ void TLoadPerambulator<FImpl>::execute(void)
         LOG(Message) <<  "reading perambulator dt= " << dt << std::endl;
         int idt=it - std::begin(invT);
         std::string sPerambName {par().perambFileName};
+        sPerambName.append(".");
+        sPerambName.append(std::to_string(vm().getTrajectory()));
         sPerambName.append("/iDT_");
         sPerambName.append(std::to_string(dt));
         sPerambName.append(".");

--- a/tests/Test_exact_distil.cpp
+++ b/tests/Test_exact_distil.cpp
@@ -128,10 +128,11 @@ int main(int argc, char *argv[])
         // perabmulators
         MDistil::Perambulator::Par perambPar;
         perambPar.lapEigenPack = "lapevec";
+        perambPar.sourceBatchSize = 1; // pass by batch deflation
         perambPar.solver = "cg_" + flavour[i];
-        perambPar.perambFileName = "./Peramb_" + flavour[i] + "_nvec6";
-        perambPar.fullSolveFileName = ""; // only used for perambMode::saveSolve
-        perambPar.fullSolve = ""; // only used for perambMode::loadSolve
+        perambPar.perambOutFileName = "./Peramb_" + flavour[i] + "_nvec6";
+        perambPar.unsmSolveOutFileName = ""; // only used for perambMode::saveSolveOnly
+        perambPar.unsmSolve = ""; // only used for perambMode::loadSolve
         perambPar.distilNoise = "exact";
         perambPar.timeSources = ""; // empty -> invert on all time slices
         perambPar.perambMode = MDistil::pMode::perambOnly; // compute perambulator from lap evecs, discard unsmeared solves

--- a/tests/Test_stoch_distil.cpp
+++ b/tests/Test_stoch_distil.cpp
@@ -58,7 +58,7 @@
  *   M(phi_{l/s},phi_l)   relative RHS  
  *   M(rho,phi_l)         relative LHS       
  * 
- * We use the mode 'saveSolve' in the light-quark perambulator module. In 
+ * We use the mode 'saveSolveOnly' in the light-quark perambulator module. In 
  * addition to computing the perambulators, it also saves the unsmeared 
  * solves on disk. These can late be contracted into meson fields by 
  * passing the filename via the input parameters
@@ -173,12 +173,12 @@ int main(int argc, char *argv[])
             MDistil::Perambulator::Par perambPar;
             perambPar.lapEigenPack = "lapevec";
             perambPar.solver = "cg_" + flavour[i];
-            perambPar.perambFileName = "./kpi-stoch/Peramb_" + flavour[i] + "_" + noises[j];
-            perambPar.fullSolveFileName = "./kpi-stoch/unsmeared_solve_" + flavour[i] + "_" + noises[j]; // only used for perambMode::saveSolve
-            perambPar.fullSolve = ""; // only used for perambMode::loadSolve
+            perambPar.perambOutFileName = "./kpi-stoch/Peramb_" + flavour[i] + "_" + noises[j];
+            perambPar.unsmSolveOutFileName = "./kpi-stoch/unsmeared_solve_" + flavour[i] + "_" + noises[j]; // only used for perambMode::saveSolveOnly
+            perambPar.unsmSolve = ""; // only used for perambMode::loadSolve
             perambPar.distilNoise = noises[j];
             perambPar.timeSources = tSrcs[j]; // time slices to invert on
-            perambPar.perambMode = MDistil::pMode::saveSolve; // compute perambulator from lap evecs, save unsmeared solves to disk
+            perambPar.perambMode = MDistil::pMode::saveSolveOnly; // compute perambulator from lap evecs, save unsmeared solves to disk
             perambPar.nVec = ""; // empty = match nVec in distilNoise
             application.createModule<MDistil::Perambulator>("Peramb_" + flavour[i] + "_" + noises[j], perambPar);
         }


### PR DESCRIPTION
Allows construction of meson fields from unsmeared solves on Tursa CPU (with certain limitations). Main changes in the memory footprint of the distillation meson field (strongly tested):
- hold in memory half the number of vectors with were held before without computational penalty
- meson field io buffers have a local size now (before it had the same size on every node but just a small fraction of it was used)

Minor changes: renaming of parameters and changes (mainly aesthetic) in Perambulator, LoadPerambulator and MesonField modules; added a variation of DistilMatrixIo::load() currently used in contractor