### PR TITLE
Added getOutputFiles method to NPR modules.

### DIFF
--- a/Hadrons/Modules/MNPR/Bilinear.hpp
+++ b/Hadrons/Modules/MNPR/Bilinear.hpp
@@ -94,6 +94,7 @@ public:
     // dependencies/products
     virtual std::vector<std::string> getInput(void);
     virtual std::vector<std::string> getOutput(void);
+    virtual std::vector<std::string> getOutputFiles(void);
     // setup
     virtual void setup(void);
     // execution
@@ -140,6 +141,14 @@ std::vector<std::string> TBilinear<FImpl>::getOutput(void)
     std::vector<std::string> out = {};
 
     return out;
+}
+
+template <typename FImpl>
+std::vector<std::string> TBilinear<FImpl>::getOutputFiles(void)
+{
+    std::vector<std::string> output = {resultFilename(par().output)};
+
+    return output;
 }
 
 template <typename FImpl>

--- a/Hadrons/Modules/MNPR/ExternalLeg.hpp
+++ b/Hadrons/Modules/MNPR/ExternalLeg.hpp
@@ -75,6 +75,7 @@ public:
     // dependencies/products
     virtual std::vector<std::string> getInput(void);
     virtual std::vector<std::string> getOutput(void);
+    virtual std::vector<std::string> getOutputFiles(void);
     // setup
     virtual void setup(void);
     // execution
@@ -118,6 +119,14 @@ std::vector<std::string> TExternalLeg<FImpl>::getOutput(void)
     std::vector<std::string> out = {};
 
     return out;
+}
+
+template <typename FImpl>
+std::vector<std::string> TExternalLeg<FImpl>::getOutputFiles(void)
+{
+    std::vector<std::string> output = {resultFilename(par().output)};
+
+    return output;
 }
 
 // execution ///////////////////////////////////////////////////////////////////

--- a/Hadrons/Modules/MNPR/FourQuarkFullyConnected.hpp
+++ b/Hadrons/Modules/MNPR/FourQuarkFullyConnected.hpp
@@ -75,6 +75,7 @@ public:
 
     virtual std::vector<std::string> getInput();
     virtual std::vector<std::string> getOutput();
+    virtual std::vector<std::string> getOutputFiles(void);
 
 protected:
     virtual void setup(void);
@@ -102,6 +103,14 @@ std::vector<std::string> TFourQuarkFullyConnected<FImpl>::getOutput()
     std::vector<std::string> out = {};
 
     return out;
+}
+
+template <typename FImpl>
+std::vector<std::string> TFourQuarkFullyConnected<FImpl>::getOutputFiles(void)
+{
+    std::vector<std::string> output = {resultFilename(par().output)};
+
+    return output;
 }
 
 template <typename FImpl>

--- a/Hadrons/Modules/MNPR/FourQuarkLoop.hpp
+++ b/Hadrons/Modules/MNPR/FourQuarkLoop.hpp
@@ -164,6 +164,7 @@ public:
 
     virtual std::vector<std::string> getInput();
     virtual std::vector<std::string> getOutput();
+    virtual std::vector<std::string> getOutputFiles(void);
 
 protected:
     virtual void setup(void);
@@ -191,6 +192,14 @@ std::vector<std::string> TFourQuarkLoop<FImpl>::getOutput()
     std::vector<std::string> out = {getName()};
 
     return out;
+}
+
+template <typename FImpl>
+std::vector<std::string> TFourQuarkLoop<FImpl>::getOutputFiles(void)
+{
+    std::vector<std::string> output = {resultFilename(par().output)};
+
+    return output;
 }
 
 template <typename FImpl>

--- a/Hadrons/Modules/MNPR/G1.hpp
+++ b/Hadrons/Modules/MNPR/G1.hpp
@@ -74,6 +74,7 @@ public:
     // dependency relation
     virtual std::vector<std::string> getInput(void);
     virtual std::vector<std::string> getOutput(void);
+    virtual std::vector<std::string> getOutputFiles(void);
 
     // setup
     virtual void setup(void);
@@ -107,6 +108,14 @@ std::vector<std::string> TG1<FImpl>::getOutput(void)
     std::vector<std::string> out = {getName()};
 
     return out;
+}
+
+template <typename FImpl>
+std::vector<std::string> TG1<FImpl>::getOutputFiles(void)
+{
+    std::vector<std::string> output = {resultFilename(par().output)};
+
+    return output;
 }
 
 // setup ///////////////////////////////////////////////////////////////////////

--- a/Hadrons/Modules/MNPR/SubtractionOperators.hpp
+++ b/Hadrons/Modules/MNPR/SubtractionOperators.hpp
@@ -84,6 +84,7 @@ public:
     // dependency relation
     virtual std::vector<std::string> getInput(void);
     virtual std::vector<std::string> getOutput(void);
+    virtual std::vector<std::string> getOutputFiles(void);
 
     // setup
     virtual void setup(void);
@@ -119,6 +120,13 @@ std::vector<std::string> TSubtractionOperators<FImpl>::getOutput(void)
     return out;
 }
 
+template <typename FImpl>
+std::vector<std::string> TSubtractionOperators<FImpl>::getOutputFiles(void)
+{
+    std::vector<std::string> output = {resultFilename(par().output)};
+
+    return output;
+}
 
 // setup ///////////////////////////////////////////////////////////////////////
 template <typename FImpl>


### PR DESCRIPTION
I revisited the NPR application I was working on and found the reason why the result database was not working as expected: The NPR modules where missing the `getOutputFiles` method.

This PR should fix the issue.