### PR TITLE
Naive scheduler

### DIFF
--- a/Hadrons/Application.cpp
+++ b/Hadrons/Application.cpp
@@ -192,18 +192,18 @@ void Application::run(void)
     }
     if (getPar().saveSchedule or getPar().scheduleFile.empty())
     {
-        if (getPar().scheduler.scheduleType == "genetic")
+        if (getPar().scheduler.schedulerType == "genetic")
         {
-            scheduler();
+            schedule();
         }
-        else if (getPar().scheduler.scheduleType == "naive")
+        else if (getPar().scheduler.schedulerType == "naive")
         {
             naiveSchedule();
         }
         else
         {
             HADRONS_ERROR(Parsing, "Unkown scheduler "
-                                + getPar().scheduler.scheduleType + "'");
+                                + getPar().scheduler.schedulerType + "'");
         }
         if (getPar().saveSchedule)
         {

--- a/Hadrons/Application.cpp
+++ b/Hadrons/Application.cpp
@@ -293,6 +293,15 @@ void Application::schedule(void)
     }
 }
 
+void Application::naiveSchedule(void)
+{
+    if (!scheduled_ and !loadedSchedule_)
+    {
+        program_   = vm().naiveSchedule();
+        scheduled_ = true;
+    }
+}
+
 void Application::saveSchedule(const std::string filename)
 {
     LOG(Message) << "Saving current schedule to '" << filename << "'..."

--- a/Hadrons/Application.cpp
+++ b/Hadrons/Application.cpp
@@ -202,7 +202,7 @@ void Application::run(void)
         }
         else
         {
-            HADRONS_ERROR(Parsing, "Unkown scheduler "
+            HADRONS_ERROR(Parsing, "Unkown scheduler '"
                                 + getPar().scheduler.schedulerType + "'");
         }
         if (getPar().saveSchedule)

--- a/Hadrons/Application.cpp
+++ b/Hadrons/Application.cpp
@@ -192,7 +192,19 @@ void Application::run(void)
     }
     if (getPar().saveSchedule or getPar().scheduleFile.empty())
     {
-        schedule();
+        if (getPar().scheduler.scheduleType == "genetic")
+        {
+            scheduler();
+        }
+        else if (getPar().scheduler.scheduleType == "naive")
+        {
+            naiveSchedule();
+        }
+        else
+        {
+            HADRONS_ERROR(Parsing, "Unkown scheduler "
+                                + getPar().scheduler.scheduleType + "'");
+        }
         if (getPar().saveSchedule)
         {
             std::string filename;

--- a/Hadrons/Application.hpp
+++ b/Hadrons/Application.hpp
@@ -114,6 +114,7 @@ public:
     void saveParameterFile(const std::string parameterFileName, unsigned int prec = 15);
     // schedule computation
     void schedule(void);
+    void naiveSchedule(void);
     void saveSchedule(const std::string filename);
     void loadSchedule(const std::string filename);
     void printSchedule(void);

--- a/Hadrons/Application.hpp
+++ b/Hadrons/Application.hpp
@@ -65,12 +65,20 @@ public:
         restoreSchedule{false}, statDbBase{""} {}
     };
 
+    struct SchedulerPar: Serializable
+    {
+        GRID_SERIALIZABLE_CLASS_MEMBERS(SchedulerPar,
+                                        std::string, schedulerType,);
+        SchedulerPar(void): schedulerType{"genetic"} {}
+    };
+
     struct GlobalPar: Serializable
     {
         GRID_SERIALIZABLE_CLASS_MEMBERS(GlobalPar,
                                         TrajRange,                  trajCounter,
                                         DatabasePar,                database,
                                         VirtualMachine::GeneticPar, genetic,
+                                        SchedulerPar,               scheduler,
                                         std::string,                runId,
                                         std::string,                graphFile,
                                         std::string,                scheduleFile,

--- a/Hadrons/VirtualMachine.cpp
+++ b/Hadrons/VirtualMachine.cpp
@@ -945,13 +945,21 @@ VirtualMachine::Program VirtualMachine::naiveSchedule(void)
     for (unsigned int i = 0; i < graph.size(); ++i)
     {
         p.push_back(i);
-
-        ScheduleEntry s;
-        s.step     = i;
-        s.moduleId = i;
-        db_->insert("schedule", s);
     }
 
+    if (hasDatabase() and makeScheduleDb_)
+    {
+        for (unsigned int i = 0; i < p.size(); ++i)
+        {
+            ScheduleEntry s;
+
+            s.step     = i;
+            s.moduleId = p[i];
+            db_->insert("schedule", s);
+        }
+    }
+
+    LOG(Message) << "Naive scheduler finished." << std::endl;
     return p;
 }
 

--- a/Hadrons/VirtualMachine.cpp
+++ b/Hadrons/VirtualMachine.cpp
@@ -959,7 +959,6 @@ VirtualMachine::Program VirtualMachine::naiveSchedule(void)
         }
     }
 
-    LOG(Message) << "Naive scheduler finished." << std::endl;
     return p;
 }
 

--- a/Hadrons/VirtualMachine.cpp
+++ b/Hadrons/VirtualMachine.cpp
@@ -934,6 +934,27 @@ VirtualMachine::Program VirtualMachine::schedule(const GeneticPar &par)
     return scheduler.getMinSchedule();
 }
 
+// naive scheduler ///////////////////////////////////////////////////////////
+VirtualMachine::Program VirtualMachine::naiveSchedule(void)
+{
+    LOG(Message) << "Using naive scheduler." << std::endl;
+    auto graph = getModuleGraph();
+
+    Program p;
+
+    for (unsigned int i = 0; i < graph.size(); ++i)
+    {
+        p.push_back(i);
+
+        ScheduleEntry s;
+        s.step     = i;
+        s.moduleId = i;
+        db_->insert("schedule", s);
+    }
+
+    return p;
+}
+
 // general execution ///////////////////////////////////////////////////////////
 #define BIG_SEP   "================"
 #define SEP       "----------------"

--- a/Hadrons/VirtualMachine.hpp
+++ b/Hadrons/VirtualMachine.hpp
@@ -188,6 +188,8 @@ public:
     Size                memoryNeeded(const Program &p);
     // genetic scheduler
     Program             schedule(const GeneticPar &par);
+    // naive scheduler
+    Program             naiveSchedule(void);
     // general execution
     void                executeProgram(const Program &p);
     void                executeProgram(const std::vector<std::string> &p);


### PR DESCRIPTION
I implemented an alternative scheduler which I call "naive". All it does is schedule modules in the order they are created. I need this feature for workflows with many `WilsonClover` type actions. As the Clover term is calculated in the constructor of the action the genetic scheduling for this kind of applications can exceed wall clock time. I think also @rrhodgson has applications where this kind of scheduling is needed.

The alternative scheduler can be chosen via the following addition to the xml global header
```xml
<scheduler>
    <schedulerType>naive</schedulerType>
</scheduler>
```
If no scheduler is specified Hadrons defaults to the genetic algorithm but raises a warning.

For a more consistent naming one could consider renaming `schedule` into `geneticSchedule`.