### PR TITLE
Feature/file bundling

### DIFF
--- a/Hadrons/Modules/MContraction/Meson.hpp
+++ b/Hadrons/Modules/MContraction/Meson.hpp
@@ -33,6 +33,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 
 BEGIN_HADRONS_NAMESPACE
 
@@ -152,7 +153,7 @@ std::vector<std::string> TMeson<FImpl1, FImpl2>::getInput(void)
 template <typename FImpl1, typename FImpl2>
 std::vector<std::string> TMeson<FImpl1, FImpl2>::getOutput(void)
 {
-    std::vector<std::string> output = {};
+    std::vector<std::string> output = {getName()};
     
     return output;
 }
@@ -170,6 +171,7 @@ template <typename FImpl1, typename FImpl2>
 void TMeson<FImpl1, FImpl2>::setup(void)
 {
     envTmpLat(LatticeComplex, "c");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -250,6 +252,8 @@ void TMeson<FImpl1, FImpl2>::execute(void)
         }
     }
     saveResult(par().output, "meson", result);
+    auto &out = envGet(HadronsSerializable, getName());
+    out = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MContraction/WeakNonEye3pt.hpp
+++ b/Hadrons/Modules/MContraction/WeakNonEye3pt.hpp
@@ -32,6 +32,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 
 BEGIN_HADRONS_NAMESPACE
 
@@ -127,7 +128,7 @@ std::vector<std::string> TWeakNonEye3pt<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TWeakNonEye3pt<FImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
     
     return out;
 }
@@ -145,6 +146,7 @@ template <typename FImpl>
 void TWeakNonEye3pt<FImpl>::setup(void)
 {
     envTmpLat(ComplexField, "corr");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -198,6 +200,8 @@ void TWeakNonEye3pt<FImpl>::execute(void)
         result.push_back(r);
     }
     saveResult(par().output, "weakNonEye3pt", result);
+    auto &out = envGet(HadronsSerializable, getName());
+    out = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MIO/CorrelatorGroup.cpp
+++ b/Hadrons/Modules/MIO/CorrelatorGroup.cpp
@@ -1,0 +1,33 @@
+/*
+ * CorrelatorGroup.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2022
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Ryan Hill <rchrys.hill@gmail.com>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+#include <Hadrons/Modules/MIO/CorrelatorGroup.hpp>
+
+using namespace Grid;
+using namespace Hadrons;
+using namespace MIO;
+
+template class Grid::Hadrons::MIO::TCorrelatorGroup<FIMPL>;

--- a/Hadrons/Modules/MIO/CorrelatorGroup.hpp
+++ b/Hadrons/Modules/MIO/CorrelatorGroup.hpp
@@ -1,0 +1,128 @@
+/*
+ * CorrelatorGroup.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2022
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Ryan Hill <rchrys.hill@gmail.com>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+
+#ifndef Hadrons_MIO_CorrelatorGroup_hpp_
+#define Hadrons_MIO_CorrelatorGroup_hpp_
+
+#include <Hadrons/Global.hpp>
+#include <Hadrons/Module.hpp>
+#include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
+
+BEGIN_HADRONS_NAMESPACE
+
+/******************************************************************************
+ *                 Module to load a single field from disk                    *
+ ******************************************************************************/
+BEGIN_MODULE_NAMESPACE(MIO)
+
+class CorrelatorGroupPar: Serializable
+{
+public:
+    GRID_SERIALIZABLE_CLASS_MEMBERS(CorrelatorGroupPar,
+                                    std::vector<std::string>, contractions);
+};
+
+template<typename Impl>
+class TCorrelatorGroup: public Module<CorrelatorGroupPar>
+{
+public:
+    // constructor
+    TCorrelatorGroup(const std::string name);
+    // destructor
+    virtual ~TCorrelatorGroup(void) {};
+    // dependency relation
+    virtual std::vector<std::string> getInput(void);
+    virtual std::vector<std::string> getOutput(void);
+    virtual std::vector<std::string> getOutputFiles(void);
+    // setup
+    virtual void setup(void);
+    // execution
+    virtual void execute(void);
+};
+
+MODULE_REGISTER_TMP(CorrelatorGroup, TCorrelatorGroup<FIMPL>, MIO);
+
+/******************************************************************************
+ *                 TCorrelatorGroup implementation                            *
+ ******************************************************************************/
+// constructor /////////////////////////////////////////////////////////////////
+template <typename Impl>
+TCorrelatorGroup<Impl>::TCorrelatorGroup(const std::string name)
+: Module<CorrelatorGroupPar>(name)
+{}
+
+// dependencies/products ///////////////////////////////////////////////////////
+template<typename Impl>
+std::vector<std::string> TCorrelatorGroup<Impl>::getInput(void)
+{
+    return par().contractions;
+}
+
+template<typename Impl>
+std::vector<std::string> TCorrelatorGroup<Impl>::getOutput(void)
+{
+    std::vector<std::string> output = {getName()};
+    
+    return output;
+}
+
+template<typename Impl>
+std::vector<std::string> TCorrelatorGroup<Impl>::getOutputFiles(void)
+{
+    std::vector<std::string> out = {};
+    
+    return out;
+}
+
+// setup ///////////////////////////////////////////////////////////////////////
+template<typename Impl>
+void TCorrelatorGroup<Impl>::setup(void)
+{
+    envCreate(HadronsSerializable, getName(), 1, 0);
+}
+
+// execution ///////////////////////////////////////////////////////////////////
+template<typename Impl>
+void TCorrelatorGroup<Impl>::execute(void)
+{
+    auto &contractionList = par().contractions;
+    auto &out             = envGet(HadronsSerializable, getName());
+    auto &result          = out.template hold<HadronsSerializableGroup>(contractionList.size());
+
+    for (const auto &contractionModuleName : contractionList)
+    {
+        auto &moduleResults = envGet(HadronsSerializable, contractionModuleName);
+        result.append(contractionModuleName, moduleResults);
+    }
+}
+
+END_MODULE_NAMESPACE
+
+END_HADRONS_NAMESPACE
+
+#endif // Hadrons_MIO_CorrelatorGroup_hpp_

--- a/Hadrons/Modules/MIO/WriteCorrelatorGroup.cpp
+++ b/Hadrons/Modules/MIO/WriteCorrelatorGroup.cpp
@@ -1,0 +1,33 @@
+/*
+ * WriteCorrelators.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2022
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Ryan Hill <rchrys.hill@gmail.com>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+#include <Hadrons/Modules/MIO/WriteCorrelatorGroup.hpp>
+
+using namespace Grid;
+using namespace Hadrons;
+using namespace MIO;
+
+template class Grid::Hadrons::MIO::TWriteCorrelatorGroup<FIMPL,FIMPL>;

--- a/Hadrons/Modules/MIO/WriteCorrelatorGroup.hpp
+++ b/Hadrons/Modules/MIO/WriteCorrelatorGroup.hpp
@@ -1,0 +1,132 @@
+/*
+ * WriteCorrelators.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2022
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Ryan Hill <rchrys.hill@gmail.com>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+
+#ifndef Hadrons_MIO_WriteCorrelators_hpp_
+#define Hadrons_MIO_WriteCorrelators_hpp_
+
+#include <Hadrons/Global.hpp>
+#include <Hadrons/Module.hpp>
+#include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
+
+BEGIN_HADRONS_NAMESPACE
+
+/******************************************************************************
+ *                 Module to load a single field from disk                    *
+ ******************************************************************************/
+BEGIN_MODULE_NAMESPACE(MIO)
+
+class WriteCorrelatorGroupPar: Serializable
+{
+public:
+    GRID_SERIALIZABLE_CLASS_MEMBERS(WriteCorrelatorGroupPar,
+                                    std::vector<std::string>, contractions,
+                                    std::string, output);
+};
+
+template <typename FImpl1, typename FImpl2>
+class TWriteCorrelatorGroup: public Module<WriteCorrelatorGroupPar>
+{
+public:
+    // constructor
+    TWriteCorrelatorGroup(const std::string name);
+    // destructor
+    virtual ~TWriteCorrelatorGroup(void) {};
+    // dependency relation
+    virtual std::vector<std::string> getInput(void);
+    virtual std::vector<std::string> getOutput(void);
+    virtual std::vector<std::string> getOutputFiles(void);
+    // setup
+    virtual void setup(void);
+    // execution
+    virtual void execute(void);
+};
+
+MODULE_REGISTER_TMP(WriteCorrelatorGroup, ARG(TWriteCorrelatorGroup<FIMPL, FIMPL>), MIO);
+
+/******************************************************************************
+ *                TWriteCorrelators implementation                            *
+ ******************************************************************************/
+// constructor /////////////////////////////////////////////////////////////////
+template <typename FImpl1, typename FImpl2>
+TWriteCorrelatorGroup<FImpl1, FImpl2>::TWriteCorrelatorGroup(const std::string name)
+: Module<WriteCorrelatorGroupPar>(name)
+{}
+
+// dependencies/products ///////////////////////////////////////////////////////
+template <typename FImpl1, typename FImpl2>
+std::vector<std::string> TWriteCorrelatorGroup<FImpl1, FImpl2>::getInput(void)
+{
+    return par().contractions;
+}
+
+template <typename FImpl1, typename FImpl2>
+std::vector<std::string> TWriteCorrelatorGroup<FImpl1, FImpl2>::getOutput(void)
+{
+    std::vector<std::string> out = {};
+    
+    return out;
+}
+
+template <typename FImpl1, typename FImpl2>
+std::vector<std::string> TWriteCorrelatorGroup<FImpl1, FImpl2>::getOutputFiles(void)
+{
+    std::vector<std::string> out = {resultFilename(par().output)};
+    
+    return out;
+}
+
+// setup ///////////////////////////////////////////////////////////////////////
+template <typename FImpl1, typename FImpl2>
+void TWriteCorrelatorGroup<FImpl1, FImpl2>::setup(void)
+{
+    
+}
+
+// execution ///////////////////////////////////////////////////////////////////
+template <typename FImpl1, typename FImpl2>
+void TWriteCorrelatorGroup<FImpl1, FImpl2>::execute(void)
+{
+    auto &contractionList = par().contractions; // Switch to std::vector with <elem></elem> tags
+
+    HadronsSerializableGroup result(contractionList.size());
+    for (const auto &contractionModuleName : contractionList)
+    {
+        auto &moduleResults = envGet(HadronsSerializable, contractionModuleName);
+        result.append(contractionModuleName, moduleResults);
+    }
+
+    // Pass a blank string to dump the unpacked group the file, rather than
+    // adding a forced and useless outer group around the result
+    saveResult(par().output, "", result);
+}
+
+END_MODULE_NAMESPACE
+
+END_HADRONS_NAMESPACE
+
+#endif // Hadrons_MIO_WriteCorrelators_hpp_

--- a/Hadrons/Modules/MIO/WriteCorrelatorGroup.hpp
+++ b/Hadrons/Modules/MIO/WriteCorrelatorGroup.hpp
@@ -36,7 +36,7 @@
 BEGIN_HADRONS_NAMESPACE
 
 /******************************************************************************
- *                 Module to load a single field from disk                    *
+ *   Module to write an arbitrary collection of Grid::Serializables to disk   *
  ******************************************************************************/
 BEGIN_MODULE_NAMESPACE(MIO)
 

--- a/Hadrons/Serialization.hpp
+++ b/Hadrons/Serialization.hpp
@@ -171,20 +171,22 @@ public:
     }
 
     template<typename T>
-    void append(const std::string& name, const T& serializable)
+    void append(const std::string& name, const T& grid_serializable)
+    {
+        this->createElement<T>(name) = grid_serializable;
+    }
+
+    auto& createElement(const std::string& name)
     {
         this->elements.emplace_back(GroupElement{name, Element_t{}});
         auto& elem = this->elements.back();
-        auto& held = elem.serializable.template hold<T>();
-        held = serializable;
+        return elem.serializable;
     }
 
     template<typename T>
     T& createElement(const std::string& name)
     {
-        this->elements.emplace_back(GroupElement{name, Element_t{}});
-        auto& elem = this->elements.back();
-        return elem.serializable.template hold<T>();
+        return this->createElement(name).template hold<T>();
     }
 
     SerializableGroup& createSubGroup(const std::string& name)
@@ -197,7 +199,7 @@ public:
         if (!s.empty())
             wr.push(s);
         
-        for (auto& elem : output.elements)
+        for (const auto& elem : output.elements)
         {
             auto& name = elem.name;
             auto& serializable = elem.serializable;

--- a/Hadrons/Serialization.hpp
+++ b/Hadrons/Serialization.hpp
@@ -1,0 +1,220 @@
+/*
+ * Serialization.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2022
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Ryan Hill <rchrys.hill@gmail.com>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+
+#ifndef Hadrons_Serialization_hpp_
+#define Hadrons_Serialization_hpp_
+
+#include <Hadrons/Global.hpp>
+
+BEGIN_HADRONS_NAMESPACE
+
+// ############# //
+// FILE CONTENTS //
+// ############# //
+// This file consists of:
+// ## Main Objects ##
+// - GenericSerializable
+//   This is a type-erased holder for Grid::Serializable subclasses and
+//   collections thereof
+//   Under a specific template specialisation for the reader and writer objects, 
+//   GenericSerializables can be used to create collections of disparate
+//   Grid::Serializables, e.g. std::vector<GenericSerializable<...>>.
+//
+// - SerializableGroup
+//   This is a class that holds an std::vector of named GenericSerializables.
+//
+// ## General-purpose Typedefs ##
+// - HadronsSerializable
+//   A specialisation of GenericSerialzable with the default Hadrons reader
+//   and writer classes.
+//   NOTE: Most developers will want to use this typedef for type-erasing
+//   Grid::Serializables.
+//
+// - HadronsSerializableGroup
+//   A specialisation a SerializableGroup with the default Hadrons reader
+//   and writer classes.
+//   NOTE: Most developers will want to use this typedef for making collections
+//   of Grid::Serializables.
+
+
+// ############ //
+// MAIN OBJECTS //
+// ############ //
+
+// type-erased holder for any Grid::Serializable descendant object
+template<typename WriterType, typename ReaderType> // 
+class GenericSerializable : Serializable
+{
+public:
+    // ############ //
+    // CONSTRUCTORS //
+    // ############ //
+    // Constructors
+    GenericSerializable()             {}
+    GenericSerializable(int i)        {}
+    template<typename T>
+    GenericSerializable(const T& obj) { this->hold<T>(obj); }
+
+    // Copy assignment constructors
+    template<typename T>
+    typename std::enable_if<!std::is_base_of<GenericSerializable, T>::value, GenericSerializable&>::type
+    operator=(const T& obj)
+    {
+        this->hold<T>(obj);
+        return *this;
+    }
+
+    // ############ //
+    // TYPE ERASURE //
+    // ############ //
+    template<typename T, typename... Args>
+    T& hold(Args&&... args)
+    {
+        auto model_ptr = std::make_shared<Model<T>>(T{std::forward<Args>(args)...});
+        this->object = model_ptr;
+        return model_ptr->serializable;
+    }
+
+    struct Concept
+    {
+        virtual ~Concept() {}
+        virtual void write(WriterType& wr, const std::string &s) const = 0;
+    };
+
+    template<typename U>
+    struct Model final : Concept
+    {
+        U serializable;
+        
+        Model()                             {}
+        Model(const U& u) : serializable(u) {}
+
+        void write(WriterType& writer, const std::string &s) const override
+        {
+            writer.write(s, serializable);
+        }
+    };
+
+    // ######### //
+    // INTERFACE //
+    // ######### //
+    static inline void write(WriterType& wr, const std::string &s, const GenericSerializable& output)
+    {
+        output.object->write(wr, s);
+    }
+
+private:
+    // ############### //
+    // PRIVATE MEMBERS //
+    // ############### //
+    std::shared_ptr<const Concept> object=nullptr;
+};
+
+// a directly writeable holder for std::vectors of GenericSerializables that 
+// ensures the group name is pushed onto the write stack when written
+template<typename WriterType, typename ReaderType>
+class SerializableGroup : Serializable
+{
+public:
+    // ####### //
+    // HELPERS //
+    // ####### //
+    typedef GenericSerializable<WriterType, ReaderType> Element_t;
+
+    struct GroupElement
+    {
+        std::string name;
+        Element_t serializable;
+    };
+
+    // ############# //
+    // PULIC MEMBERS //
+    // ############# //
+    std::vector<GroupElement> elements;
+
+    // ############ //
+    // CONSTRUCTORS //
+    // ############ //
+    SerializableGroup()                         {}
+    SerializableGroup(unsigned long elem_count) { this->elements.reserve(elem_count); }
+
+    // ######### //
+    // INTERFACE //
+    // ######### //
+    void append(const std::string& name, const Element_t& serializable)
+    {
+        this->elements.emplace_back(GroupElement{name, serializable});
+    }
+
+    template<typename T>
+    void append(const std::string& name, const T& serializable)
+    {
+        this->elements.emplace_back(GroupElement{name, Element_t{}});
+        auto& elem = this->elements.back();
+        auto& held = elem.serializable.template hold<T>();
+        held = serializable;
+    }
+
+    template<typename T>
+    T& createElement(const std::string& name)
+    {
+        this->elements.emplace_back(GroupElement{name, Element_t{}});
+        auto& elem = this->elements.back();
+        return elem.serializable.template hold<T>();
+    }
+
+    SerializableGroup& createSubGroup(const std::string& name)
+    {
+        return this->createElement<SerializableGroup>(name);
+    }
+
+    static inline void write(WriterType& wr, const std::string &s, const SerializableGroup& output)
+    {
+        if (!s.empty())
+            wr.push(s);
+        
+        for (auto& elem : output.elements)
+        {
+            auto& name = elem.name;
+            auto& serializable = elem.serializable;
+            serializable.write(wr, name, serializable);
+        }   
+        
+        if (!s.empty())
+            wr.pop();
+    }
+};
+
+// ######################## //
+// GENERAL-PURPOSE TYPEDEFS //
+// ######################## //
+typedef GenericSerializable<Grid::Writer<ResultWriter>, Grid::Writer<ResultReader>> HadronsSerializable;
+typedef SerializableGroup  <Grid::Writer<ResultWriter>, Grid::Writer<ResultReader>> HadronsSerializableGroup;
+
+END_HADRONS_NAMESPACE
+
+#endif // Hadrons_Serialization_hpp_

--- a/Hadrons/Serialization.hpp
+++ b/Hadrons/Serialization.hpp
@@ -75,7 +75,7 @@ public:
     // ############ //
     // Constructors
     GenericSerializable()             {}
-    GenericSerializable(int i)        {}
+    GenericSerializable(int i)        {} // Placeholder constructor that works with variadic macros
     template<typename T>
     GenericSerializable(const T& obj) { this->hold<T>(obj); }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_PROGRAMS = \
   Test_hadrons_meson_3pt    \
   Test_hadrons_spectrum     \
   Test_highfreq_stat        \
+  Test_result_bundling      \
   Test_sigma_to_nucleon     \
   Test_stoch_distil         \
   Test_xi_to_sigma
@@ -53,6 +54,9 @@ Test_hadrons_spectrum_LDADD=-lHadrons -lGrid
 
 Test_highfreq_stat_SOURCES=Test_highfreq_stat.cpp
 Test_highfreq_stat_LDADD=-lHadrons -lGrid
+
+Test_result_bundling_SOURCES=Test_result_bundling.cpp
+Test_result_bundling_LDADD=-lHadrons -lGrid
 
 Test_sigma_to_nucleon_SOURCES=Test_sigma_to_nucleon.cpp
 Test_sigma_to_nucleon_LDADD=-lHadrons -lGrid

--- a/tests/Test_result_bundling.cpp
+++ b/tests/Test_result_bundling.cpp
@@ -1,0 +1,151 @@
+/*
+ * Test_field_io.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2022
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Ryan Hill <rchrys.hill@gmail.com>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+#include <Hadrons/Application.hpp>
+#include <Hadrons/Modules.hpp>
+
+using namespace Grid;
+using namespace Hadrons;
+
+int main(int argc, char *argv[])
+{
+    // initialization //////////////////////////////////////////////////////////
+    Grid_init(&argc, &argv);
+    HadronsLogError.Active(GridLogError.isActive());
+    HadronsLogWarning.Active(GridLogWarning.isActive());
+    HadronsLogMessage.Active(GridLogMessage.isActive());
+    HadronsLogIterative.Active(GridLogIterative.isActive());
+    HadronsLogDebug.Active(GridLogDebug.isActive());
+    LOG(Message) << "Grid initialized" << std::endl;
+
+
+    // run setup ///////////////////////////////////////////////////////////////
+    Application              application;
+    unsigned int  nt    = GridDefaultLatt()[Tp];
+    
+    // global parameters
+    Application::GlobalPar globalPar;
+    globalPar.trajCounter.start = 1000;
+    globalPar.trajCounter.end   = 1020;
+    globalPar.trajCounter.step  = 20;
+    globalPar.runId             = "test";
+    application.setPar(globalPar);
+    // gauge field
+    application.createModule<MGauge::Unit>("gauge");
+    // pt source
+    MSource::Point::Par ptPar;
+    ptPar.position = "0 0 0 0";
+    application.createModule<MSource::Point>("pt", ptPar);
+    // sink
+    MSink::Point::Par sinkPar;
+    sinkPar.mom = "0 0 0";
+    application.createModule<MSink::ScalarPoint>("sink", sinkPar);
+    
+    // set fermion boundary conditions to be periodic space, antiperiodic time.
+    std::string boundary = "1 1 1 -1";
+    std::string twist    = "0. 0. 0. 0.";
+
+    // actions
+    MAction::DWF::Par actionPar;
+    actionPar.gauge = "gauge";
+    actionPar.Ls    = 8;
+    actionPar.M5    = 1.8;
+    actionPar.mass  = 0.03224;
+    actionPar.boundary = boundary;
+    actionPar.twist = "0. 0. 0. 0.";
+    application.createModule<MAction::DWF>("DWF_s", actionPar);
+
+    
+    // solvers
+    MSolver::RBPrecCG::Par solverPar;
+    solverPar.action       = "DWF_s";
+    solverPar.residual     = 1.0e-8;
+    solverPar.maxIteration = 10000;
+    application.createModule<MSolver::RBPrecCG>("CG_s",
+                                                solverPar);
+    
+    // propagators
+    MFermion::GaugeProp::Par quarkPar;
+    quarkPar.solver = "CG_s";
+    quarkPar.source = "pt";
+    application.createModule<MFermion::GaugeProp>("Qpt_s",
+                            quarkPar);
+
+
+    // Two Meson contractions
+    MContraction::Meson::Par mesPar;
+    mesPar.output  = "";
+    mesPar.q1      = "Qpt_s";
+    mesPar.q2      = "Qpt_s";
+    mesPar.gammas  = "(Gamma5 GammaX)";
+    mesPar.sink    = "sink";
+    application.createModule<MContraction::Meson>("meson_pt_ss_5X",
+                                                    mesPar);
+    MContraction::Meson::Par mesPar2;
+    mesPar2.q1      = "Qpt_s";
+    mesPar2.q2      = "Qpt_s";
+    mesPar2.gammas  = "(Gamma5 GammaY) (Gamma5 GammaZ)";
+    mesPar2.sink    = "sink";
+    mesPar2.output  = "";
+    application.createModule<MContraction::Meson>("meson_pt_ss_5Y",
+                                                    mesPar2);
+
+    // A Weak Eye contraction
+    MContraction::WeakNonEye3pt::Par weakNonEyePar;
+    weakNonEyePar.qLeft     = "Qpt_s";
+    weakNonEyePar.qBarLeft  = "Qpt_s";
+    weakNonEyePar.qRight    = "Qpt_s";
+    weakNonEyePar.qBarRight = "Qpt_s";
+    weakNonEyePar.gammaIn  = Gamma::Algebra::GammaT;
+    weakNonEyePar.gammaOut = Gamma::Algebra::Gamma5;
+    weakNonEyePar.output    = "";
+    application.createModule<MContraction::WeakNonEye3pt>("meson_noneye_ss",
+                                                           weakNonEyePar);
+
+    // Demonstrate the bundling of two Serializables within a group
+    MIO::CorrelatorGroup::Par correlatorGroupPar;
+    correlatorGroupPar.contractions = std::vector<std::string>{"meson_pt_ss_5X", "meson_pt_ss_5Y"};
+    application.createModule<MIO::CorrelatorGroup>("Group2pts",
+                                                    correlatorGroupPar);
+
+    // Now demonstrate bundling the group with another Serializable
+    MIO::WriteCorrelatorGroup::Par writeCorrelatorGroupPar;
+    writeCorrelatorGroupPar.contractions = std::vector<std::string>{"meson_noneye_ss", "Group2pts"};
+    writeCorrelatorGroupPar.output       = "resultbundle_test/output";
+    application.createModule<MIO::WriteCorrelatorGroup>("WriteToFile",
+                                                        writeCorrelatorGroupPar);
+
+
+    // execution
+    application.saveParameterFile("ResultBundling.xml");
+    application.run();
+    
+    // epilogue
+    LOG(Message) << "Grid is finalizing now" << std::endl;
+    Grid_finalize();
+    
+    return EXIT_SUCCESS;
+}

--- a/tests/Test_result_bundling.cpp
+++ b/tests/Test_result_bundling.cpp
@@ -1,5 +1,5 @@
 /*
- * Test_field_io.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ * Test_result_bundling.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
  *
  * Copyright (C) 2015 - 2022
  *

--- a/tests/Test_result_bundling.cpp
+++ b/tests/Test_result_bundling.cpp
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
 
     // Two Meson contractions
     MContraction::Meson::Par mesPar;
-    mesPar.output  = "";
+    mesPar.output  = "resultbundle_test/original_2pt_output";
     mesPar.q1      = "Qpt_s";
     mesPar.q2      = "Qpt_s";
     mesPar.gammas  = "(Gamma5 GammaX)";
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
     mesPar2.gammas  = "(Gamma5 GammaY) (Gamma5 GammaZ)";
     mesPar2.sink    = "sink";
     mesPar2.output  = "";
-    application.createModule<MContraction::Meson>("meson_pt_ss_5Y",
+    application.createModule<MContraction::Meson>("meson_pt_ss_5YZ",
                                                     mesPar2);
 
     // A Weak Eye contraction
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
 
     // Demonstrate the bundling of two Serializables within a group
     MIO::CorrelatorGroup::Par correlatorGroupPar;
-    correlatorGroupPar.contractions = std::vector<std::string>{"meson_pt_ss_5X", "meson_pt_ss_5Y"};
+    correlatorGroupPar.contractions = std::vector<std::string>{"meson_pt_ss_5X", "meson_pt_ss_5YZ"};
     application.createModule<MIO::CorrelatorGroup>("Group2pts",
                                                     correlatorGroupPar);
 


### PR DESCRIPTION
- Adds a Serialization header that contains type-erased holders for Grid::GridSerializable objects
     - Main members: HadronsSerializable (type-erasure), HadronsSerializableGroup (collection of named HadronsSerializables)
- Creates Hadrons modules for generating groups of HadronsSerializables at runtime and writing them to disk
- Add file bundling support to MContraction::Meson and MContraction::WeakNonEye3pt
- Add a test demonstrating the use of the bundled result write on MContraction::Meson and MContraction::WeakNonEye3pt