### PR TITLE
Feature/rhq improvement tensor

### DIFF
--- a/Hadrons/Modules/MRHQ/RHQInsertionI.cpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionI.cpp
@@ -6,6 +6,7 @@
  * Author: Antonin Portelli <antonin.portelli@me.com>
  * Author: Ryan Hill <rchrys.hill@gmail.com>
  * Author: Alessandro Barone <barone1618@gmail.com>
+ * Author: Matthew Black <matthewkblack@protonmail.com>
  *
  * Hadrons is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Hadrons/Modules/MRHQ/RHQInsertionI.hpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionI.hpp
@@ -45,7 +45,7 @@ class RHQInsertionIPar: Serializable
 public:
     GRID_SERIALIZABLE_CLASS_MEMBERS(RHQInsertionIPar,
                                     std::string,    q,
-                                    unsigned int,   index,
+                                    std::string,    index,
                                     Gamma::Algebra, gamma5,
                                     std::string,    gauge);
 };
@@ -124,11 +124,11 @@ void TRHQInsertionI<FImpl, GImpl>::execute(void)
     }
     Gamma g5(par().gamma5);
 
-    if (par().index < 0 || par().index>3)
+    const int index = std::stoi(par().index);
+    if (index < 0 || index>3)
     {
         HADRONS_ERROR(Argument, "Index must be in {0, 1, 2, 3}."); 
     }
-    const auto &index = par().index;
 
     auto &field = envGet(PropagatorField, par().q);
     const auto &gaugefield = envGet(GaugeField, par().gauge);

--- a/Hadrons/Modules/MRHQ/RHQInsertionI.hpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionI.hpp
@@ -47,7 +47,7 @@ public:
     GRID_SERIALIZABLE_CLASS_MEMBERS(RHQInsertionIPar,
                                     std::string,    q,
                                     std::string,    index,
-                                    Gamma::Algebra, gamma5,
+                                    Gamma::Algebra, gamma,
                                     std::string,    gauge);
 };
 
@@ -115,15 +115,12 @@ template <typename FImpl, typename GImpl>
 void TRHQInsertionI<FImpl, GImpl>::execute(void)
 {
     LOG(Message) << "Applying Improvement term I with index " << par().index
-                 << " and gamma5=" << par().gamma5 
+                 << " and gamma=" << par().gamma 
                  << " to '" << par().q 
                  << std::endl;
 
-    if (par().gamma5 != Gamma::Algebra::Gamma5 && par().gamma5 != Gamma::Algebra::Identity)
-    {
-        HADRONS_ERROR(Argument, "gamma5 must be either 'Gamma5' or 'Identity'."); 
     }
-    Gamma g5(par().gamma5);
+    Gamma g(par().gamma);
 
     const int index = std::stoi(par().index);
     if (index < 0 || index>3)
@@ -134,7 +131,7 @@ void TRHQInsertionI<FImpl, GImpl>::execute(void)
     auto &field = envGet(PropagatorField, par().q);
     const auto &gaugefield = envGet(GaugeField, par().gauge);
     const auto internal_gauge = peekLorentz(gaugefield, index);
-    PropagatorField insertion = g5*(GImpl::CovShiftForward(internal_gauge,index,field) - GImpl::CovShiftBackward(internal_gauge,index,field));
+    PropagatorField insertion = g*(GImpl::CovShiftForward(internal_gauge,index,field) - GImpl::CovShiftBackward(internal_gauge,index,field));
     
     auto &out = envGet(PropagatorField, getName());
     out = insertion;

--- a/Hadrons/Modules/MRHQ/RHQInsertionI.hpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionI.hpp
@@ -119,7 +119,6 @@ void TRHQInsertionI<FImpl, GImpl>::execute(void)
                  << " to '" << par().q 
                  << std::endl;
 
-    }
     Gamma g(par().gamma);
 
     const int index = std::stoi(par().index);

--- a/Hadrons/Modules/MRHQ/RHQInsertionI.hpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionI.hpp
@@ -6,6 +6,7 @@
  * Author: Antonin Portelli <antonin.portelli@me.com>
  * Author: Ryan Hill <rchrys.hill@gmail.com>
  * Author: Alessandro Barone <barone1618@gmail.com>
+ * Author: Matthew Black <matthewkblack@protonmail.com>
  *
  * Hadrons is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Hadrons/Modules/MRHQ/RHQInsertionIII.cpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionIII.cpp
@@ -6,6 +6,7 @@
  * Author: Antonin Portelli <antonin.portelli@me.com>
  * Author: Ryan Hill <rchrys.hill@gmail.com>
  * Author: Alessandro Barone <barone1618@gmail.com>
+ * Author: Matthew Black <matthewkblack@protonmail.com>
  *
  * Hadrons is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Hadrons/Modules/MRHQ/RHQInsertionIII.hpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionIII.hpp
@@ -53,8 +53,12 @@ public:
 
 // See https://arxiv.org/abs/1501.05373 equation 13 for the 
 // operator implemented in this module.
-// To convert to the charge conjugation "invariant" basis,
-// see ...............
+// To convert to the charge conjugation "invariant" basis:
+// sJ = +1 if gamma5 = Identity; sJ = -1 if gamma5 = Gamma5
+// if either index1 or index2 empty:
+//     RHQIII_mu -> sJ * RHQIII_mu - delta_{mu,i} * RHQI(D_i)
+// if both index1 and index2 used:
+//     RHQIII_{mu,nu} -> sJ * RHQIII_{mu,nu} - 2 * ( delta_{nu,i} * RHQI(gamma_mu,D_i) - delta_{mu,i} * RHQI(gamma_nu,D_i) )
 template <typename FImpl, typename GImpl>
 class TRHQInsertionIII: public Module<RHQInsertionIIIPar>
 {

--- a/Hadrons/Modules/MRHQ/RHQInsertionIII.hpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionIII.hpp
@@ -6,6 +6,7 @@
  * Author: Antonin Portelli <antonin.portelli@me.com>
  * Author: Ryan Hill <rchrys.hill@gmail.com>
  * Author: Alessandro Barone <barone1618@gmail.com>
+ * Author: Matthew Black <matthewkblack@protonmail.com>
  *
  * Hadrons is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -59,6 +60,7 @@ public:
 //     RHQIII_mu -> sJ * RHQIII_mu - delta_{mu,i} * RHQI(D_i)
 // if both index1 and index2 used:
 //     RHQIII_{mu,nu} -> sJ * RHQIII_{mu,nu} - 2 * ( delta_{nu,i} * RHQI(gamma_mu,D_i) - delta_{mu,i} * RHQI(gamma_nu,D_i) )
+// also see ale-barone/feature/RHQImprTensor
 template <typename FImpl, typename GImpl>
 class TRHQInsertionIII: public Module<RHQInsertionIIIPar>
 {

--- a/Hadrons/Modules/MRHQ/RHQInsertionIII.hpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionIII.hpp
@@ -38,8 +38,6 @@ BEGIN_HADRONS_NAMESPACE
 /******************************************************************************
  *                             RHQInsertionIII                                *
  ******************************************************************************/
-GRID_SERIALIZABLE_ENUM(OpIIIFlag, undef, Chroma, 0, LeftRight, 1);
-
 BEGIN_MODULE_NAMESPACE(MRHQ)
 
 class RHQInsertionIIIPar: Serializable
@@ -50,12 +48,13 @@ public:
                                     std::string,    index1,
                                     std::string,    index2,
                                     Gamma::Algebra, gamma5,
-                                    std::string,    gauge,
-                                    OpIIIFlag,      flag);
+                                    std::string,    gauge);
 };
 
-// See https://arxiv.org/abs/1501.05373 equation 13 for the (Chroma convention) 
+// See https://arxiv.org/abs/1501.05373 equation 13 for the 
 // operator implemented in this module.
+// To convert to the charge conjugation "invariant" basis,
+// see ...............
 template <typename FImpl, typename GImpl>
 class TRHQInsertionIII: public Module<RHQInsertionIIIPar>
 {
@@ -120,7 +119,6 @@ void TRHQInsertionIII<FImpl, GImpl>::execute(void)
                  << "(" << par().index1 << ", " << par().index2 << ")"
                  << " and gamma5=" << par().gamma5 
                  << " to '" << par().q 
-                 << "' with flag '" << par().flag << "'"
                  << std::endl;
     
     if (par().gamma5 != Gamma::Algebra::Gamma5 && par().gamma5 != Gamma::Algebra::Identity)
@@ -287,34 +285,13 @@ void TRHQInsertionIII<FImpl, GImpl>::execute(void)
             }
     }
         
-    // "Flag" flips between the conventions used in Chroma and a reformulation
-    // using Left and Right derivatives
     auto &out = envGet(PropagatorField, getName());
-    if (par().flag == OpIIIFlag::Chroma)
-    {     
-        PropagatorField insertion =
-            gi*g5*gx * Dx
-          + gi*g5*gy * Dy
-          + gi*g5*gz * Dz;
-        
-        out = insertion;
-    }
-    else if (par().flag == OpIIIFlag::LeftRight)
-    {        
-        double sign;
-        if (hasIndex1 && hasIndex2){
-            sign = +1.;
-        }
-        else {
-            sign = -1.;
-        }
-        PropagatorField insertion = 
-            gi*gx*g5 * Dx + gx*gi*g5 * (sign*Dx)
-          + gi*gy*g5 * Dy + gy*gi*g5 * (sign*Dy)
-          + gi*gz*g5 * Dz + gz*gi*g5 * (sign*Dz);
-
-        out = 0.5*insertion;
-    }
+    PropagatorField insertion =
+        gi*g5*gx * Dx
+      + gi*g5*gy * Dy
+      + gi*g5*gz * Dz;
+    
+    out = insertion;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MRHQ/RHQInsertionIII.hpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionIII.hpp
@@ -47,7 +47,8 @@ class RHQInsertionIIIPar: Serializable
 public:
     GRID_SERIALIZABLE_CLASS_MEMBERS(RHQInsertionIIIPar,
                                     std::string,    q,
-                                    unsigned int,   index,
+                                    std::string,    index1,
+                                    std::string,    index2,
                                     Gamma::Algebra, gamma5,
                                     std::string,    gauge,
                                     OpIIIFlag,      flag);
@@ -115,7 +116,8 @@ void TRHQInsertionIII<FImpl, GImpl>::setup(void)
 template <typename FImpl, typename GImpl>
 void TRHQInsertionIII<FImpl, GImpl>::execute(void)
 {
-    LOG(Message) << "Applying Improvement term III with index " << par().index
+    LOG(Message) << "Applying Improvement term III with (index1, index2)=" 
+                 << "(" << par().index1 << ", " << par().index2 << ")"
                  << " and gamma5=" << par().gamma5 
                  << " to '" << par().q 
                  << "' with flag '" << par().flag << "'"
@@ -126,6 +128,25 @@ void TRHQInsertionIII<FImpl, GImpl>::execute(void)
         HADRONS_ERROR(Argument, "gamma5 must be either 'Gamma5' or 'Identity'."); 
     }
     Gamma g5(par().gamma5);
+
+    int index1;
+    int index2;
+    bool hasIndex1 = false;
+    bool hasIndex2 = false;
+    if (!par().index1.empty())
+    {
+        index1 = std::stoi(par().index1);
+        hasIndex1 = true;
+    }
+    if (!par().index2.empty())
+    {
+        index2 = std::stoi(par().index2);
+        hasIndex2 = true;
+    }
+    if (!hasIndex1 && !hasIndex2)
+    {
+        HADRONS_ERROR(Argument, "index1 and index2 cannot be both empty."); 
+    }
     
     auto &field = envGet(PropagatorField, par().q);
     const auto &gaugefield = envGet(GaugeField, par().gauge);
@@ -141,24 +162,131 @@ void TRHQInsertionIII<FImpl, GImpl>::execute(void)
     const PropagatorField Dy = GImpl::CovShiftForward(gauge_y,1,field) - GImpl::CovShiftBackward(gauge_y,1,field);
     const PropagatorField Dz = GImpl::CovShiftForward(gauge_z,2,field) - GImpl::CovShiftBackward(gauge_z,2,field);
 
-    Gamma::Algebra gi; 
-    switch(par().index){
-        case 0:
-            gi = Gamma::Algebra::GammaX;
-            break;
-        case 1:
-            gi = Gamma::Algebra::GammaY;
-            break;
-        case 2:
-            gi = Gamma::Algebra::GammaZ;
-            break;
-        case 3:
-            gi = Gamma::Algebra::GammaT;
-            break;
-        default:
-            HADRONS_ERROR(Argument, "Index must be in {0, 1, 2, 3}."); 
+    Gamma::Algebra gi;
+    if (hasIndex1 && hasIndex2)
+    {
+        switch(index1){
+            case 0:
+                switch(index2)
+                    {
+                        case 0:
+                            gi = 0.*Gamma::Algebra::Identity;
+                            break;
+                        case 1:
+                            gi = Gamma::Algebra::SigmaXY;
+                            break;
+                        case 2:
+                            gi = Gamma::Algebra::SigmaXZ;
+                            break;
+                        case 3:
+                            gi = Gamma::Algebra::SigmaXT;
+                            break;
+                        default:
+                            HADRONS_ERROR(Argument, "index2 must be in {0, 1, 2, 3}."); 
+                    }
+                break;
+            case 1:
+                switch(index2)
+                    {
+                        case 0:
+                            gi = Gamma::Algebra::MinusSigmaXY;
+                            break;
+                        case 1:
+                            gi = 0.*Gamma::Algebra::Identity;
+                            break;
+                        case 2:
+                            gi = Gamma::Algebra::SigmaYZ;
+                            break;
+                        case 3:
+                            gi = Gamma::Algebra::SigmaYT;
+                            break;
+                        default:
+                            HADRONS_ERROR(Argument, "index2 must be in {0, 1, 2, 3}."); 
+                    }
+                break;
+            case 2:
+                switch(index2)
+                    {
+                        case 0:
+                            gi = Gamma::Algebra::MinusSigmaXZ;
+                            break;
+                        case 1:
+                            gi = Gamma::Algebra::MinusSigmaYZ;
+                            break;
+                        case 2:
+                            gi = 0.*Gamma::Algebra::Identity;
+                            break;
+                        case 3:
+                            gi = Gamma::Algebra::SigmaZT;
+                            break;
+                        default:
+                            HADRONS_ERROR(Argument, "index2 must be in {0, 1, 2, 3}."); 
+                    }
+                break;
+            case 3:
+                switch(index2)
+                    {
+                        case 0:
+                            gi = Gamma::Algebra::MinusSigmaXT;
+                            break;
+                        case 1:
+                            gi = Gamma::Algebra::MinusSigmaYT;
+                            break;
+                        case 2:
+                            gi = Gamma::Algebra::MinusSigmaZT;
+                            break;
+                        case 3:
+                            gi = 0.*Gamma::Algebra::Identity;
+                            break;
+                        default:
+                            HADRONS_ERROR(Argument, "index2 must be in {0, 1, 2, 3}."); 
+                    } 
+                break;
+            default:
+                HADRONS_ERROR(Argument, "index1 must be in {0, 1, 2, 3}."); 
+        }
     }
-    
+    else if (hasIndex1 && !hasIndex2)
+    {
+        switch(index1)
+            {
+                case 0:
+                    gi = Gamma::Algebra::GammaX;
+                    break;
+                case 1:
+                    gi = Gamma::Algebra::GammaY;
+                    break;
+                case 2:
+                    gi = Gamma::Algebra::GammaZ;
+                    break;
+                case 3:
+                    gi = Gamma::Algebra::GammaT;
+                    break;
+                default:
+                    HADRONS_ERROR(Argument, "index1 must be in {0, 1, 2, 3}."); 
+            }
+    }
+    else if (!hasIndex1 && hasIndex2)
+    {
+        switch(index2)
+            {
+                case 0:
+                    gi = Gamma::Algebra::GammaX;
+                    break;
+                case 1:
+                    gi = Gamma::Algebra::GammaY;
+                    break;
+                case 2:
+                    gi = Gamma::Algebra::GammaZ;
+                    break;
+                case 3:
+                    gi = Gamma::Algebra::GammaT;
+                    break;
+                default:
+                    HADRONS_ERROR(Argument, "index2 must be in {0, 1, 2, 3}."); 
+            }
+    }
+        
     // "Flag" flips between the conventions used in Chroma and a reformulation
     // using Left and Right derivatives
     auto &out = envGet(PropagatorField, getName());
@@ -173,10 +301,17 @@ void TRHQInsertionIII<FImpl, GImpl>::execute(void)
     }
     else if (par().flag == OpIIIFlag::LeftRight)
     {        
+        double sign;
+        if (hasIndex1 && hasIndex2){
+            sign = +1.;
+        }
+        else {
+            sign = -1.;
+        }
         PropagatorField insertion = 
-            gi*gx*g5 * Dx - gx*gi*g5 * Dx
-          + gi*gy*g5 * Dy - gy*gi*g5 * Dy
-          + gi*gz*g5 * Dz - gz*gi*g5 * Dz;
+            gi*gx*g5 * Dx + gx*gi*g5 * (sign*Dx)
+          + gi*gy*g5 * Dy + gy*gi*g5 * (sign*Dy)
+          + gi*gz*g5 * Dz + gz*gi*g5 * (sign*Dz);
 
         out = 0.5*insertion;
     }

--- a/Hadrons/Modules/MRHQ/RHQInsertionIV.cpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionIV.cpp
@@ -6,6 +6,7 @@
  * Author: Antonin Portelli <antonin.portelli@me.com>
  * Author: Ryan Hill <rchrys.hill@gmail.com>
  * Author: Alessandro Barone <barone1618@gmail.com>
+ * Author: Matthew Black <matthewkblack@protonmail.com>
  *
  * Hadrons is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Hadrons/Modules/MRHQ/RHQInsertionIV.hpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionIV.hpp
@@ -6,6 +6,7 @@
  * Author: Antonin Portelli <antonin.portelli@me.com>
  * Author: Ryan Hill <rchrys.hill@gmail.com>
  * Author: Alessandro Barone <barone1618@gmail.com>
+ * Author: Matthew Black <matthewkblack@protonmail.com>
  *
  * Hadrons is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -59,6 +60,7 @@ public:
 //     RHQIV_mu -> sJ * RHQIV_mu - delta_{mu,i} * RHQI(D_i)
 // if both index1 and index2 used:
 //     RHQIV_{mu,nu} -> sJ * RHQIV_{mu,nu} - 2 * ( delta_{nu,i} * RHQI(gamma_mu,D_i) - delta_{mu,i} * RHQI(gamma_nu,D_i) )
+// also see ale-barone/feature/RHQImprTensor
 template <typename FImpl, typename GImpl>
 class TRHQInsertionIV: public Module<RHQInsertionIVPar>
 {

--- a/Hadrons/Modules/MRHQ/RHQInsertionIV.hpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionIV.hpp
@@ -54,7 +54,11 @@ public:
 // See https://arxiv.org/abs/1501.05373 equation 14 for the
 // operator implemented in this module.
 // To convert to the charge conjugation "invariant" basis,
-// see ...............
+// sJ = +1 if gamma5 = Identity; sJ = -1 if gamma5 = Gamma5
+// if either index1 or index2 empty:
+//     RHQIV_mu -> sJ * RHQIV_mu - delta_{mu,i} * RHQI(D_i)
+// if both index1 and index2 used:
+//     RHQIV_{mu,nu} -> sJ * RHQIV_{mu,nu} - 2 * ( delta_{nu,i} * RHQI(gamma_mu,D_i) - delta_{mu,i} * RHQI(gamma_nu,D_i) )
 template <typename FImpl, typename GImpl>
 class TRHQInsertionIV: public Module<RHQInsertionIVPar>
 {

--- a/Hadrons/Modules/MRHQ/RHQInsertionIV.hpp
+++ b/Hadrons/Modules/MRHQ/RHQInsertionIV.hpp
@@ -38,8 +38,6 @@ BEGIN_HADRONS_NAMESPACE
 /******************************************************************************
  *                            RHQInsertionIV                                  *
  ******************************************************************************/
-GRID_SERIALIZABLE_ENUM(OpIVFlag, undef, Chroma, 0, LeftRight, 1);
-
 BEGIN_MODULE_NAMESPACE(MRHQ)
 
 class RHQInsertionIVPar: Serializable
@@ -50,12 +48,13 @@ public:
                                     std::string,    index1,
                                     std::string,    index2,
                                     Gamma::Algebra, gamma5,
-                                    std::string,    gauge,
-                                    OpIVFlag,       flag);
+                                    std::string,    gauge);
 };
 
-// See https://arxiv.org/abs/1501.05373 equation 14 for the (Chroma convention) 
+// See https://arxiv.org/abs/1501.05373 equation 14 for the
 // operator implemented in this module.
+// To convert to the charge conjugation "invariant" basis,
+// see ...............
 template <typename FImpl, typename GImpl>
 class TRHQInsertionIV: public Module<RHQInsertionIVPar>
 {
@@ -121,7 +120,6 @@ void TRHQInsertionIV<FImpl, GImpl>::execute(void)
                  << "(" << par().index1 << ", " << par().index2 << ")"
                  << " and gamma5=" << par().gamma5 
                  << " to '" << par().q 
-                 << "' with flag '" << par().flag << "'"
                  << std::endl;
     
     if (par().gamma5 != Gamma::Algebra::Gamma5 && par().gamma5 != Gamma::Algebra::Identity)
@@ -288,36 +286,13 @@ void TRHQInsertionIV<FImpl, GImpl>::execute(void)
             }
     }
     
-    // "Flag" flips between the conventions used in Chroma and a reformulation
-    // using Left and Right derivatives
     auto &out = envGet(PropagatorField, getName());
-    if (par().flag == OpIVFlag::Chroma)
-    {     
-        PropagatorField insertion =
-            gx*g5*gi * Dx 
-          + gy*g5*gi * Dy
-          + gz*g5*gi * Dz;
-        
-        out = insertion;
-    }
-    else if (par().flag == OpIVFlag::LeftRight)
-    {      
-        double sign;
-        if (hasIndex1 && hasIndex2){
-            sign = +1.;
-        }
-        else {
-            sign = -1.;
-        }
-
-        PropagatorField insertion = 
-            gi*gx*g5 * Dx + gx*gi*g5 * (sign*Dx)
-          + gi*gy*g5 * Dy + gy*gi*g5 * (sign*Dy)
-          + gi*gz*g5 * Dz + gz*gi*g5 * (sign*Dz);
-        
-        out = -0.5*insertion;
-    }
- 
+    PropagatorField insertion =
+        gx*g5*gi * Dx 
+      + gy*g5*gi * Dy
+      + gz*g5*gi * Dz;
+    
+    out = insertion;
 }
 
 END_MODULE_NAMESPACE


### PR DESCRIPTION
- extends the RHQ modules to include (pseudo-)tensor operators 
- changes the RHQInsertionI parameter `gamma5` to `gamma` where now any Gamma matrix can be input
- changes RHQInsertionIII/IV parameter `index` to `index1` and `index2` -> using both yields the tensor structures, or leaving one empty yields the vectors as previously