### PR TITLE
Garbage collection for naive scheduler

### DIFF
--- a/Hadrons/Application.cpp
+++ b/Hadrons/Application.cpp
@@ -359,9 +359,19 @@ void Application::printSchedule(void)
     {
         HADRONS_ERROR(Definition, "Computation not scheduled");
     }
-    auto peak = vm().memoryNeeded(program_);
-    LOG(Message) << "Schedule (memory needed: " << sizeString(peak) << "):"
-                 << std::endl;
+
+    if (getPar().scheduler.schedulerType == "naive")
+    {
+        LOG(Message) << "Schedule:"
+                    << std::endl;
+    }
+    else
+    {
+        auto peak = vm().memoryNeeded(program_);
+        LOG(Message) << "Schedule (memory needed: " << sizeString(peak) << "):"
+                    << std::endl;
+    }
+
     for (unsigned int i = 0; i < program_.size(); ++i)
     {
         LOG(Message) << std::setw(4) << i + 1 << ": "

--- a/Hadrons/VirtualMachine.cpp
+++ b/Hadrons/VirtualMachine.cpp
@@ -1035,8 +1035,7 @@ void VirtualMachine::executeProgram(const Program &p)
         // Clean up remaining temporary objects
         for (unsigned int a = 0; a < env().getMaxAddress(); ++a)
         {
-            if (env().getObjectStorage(a) == Environment::Storage::temporary
-                and env().hasCreatedObject(a))
+            if (env().getObjectStorage(a) == Environment::Storage::temporary)
             {
                 env().freeObject(a);
             }

--- a/Hadrons/VirtualMachine.cpp
+++ b/Hadrons/VirtualMachine.cpp
@@ -1031,6 +1031,18 @@ void VirtualMachine::executeProgram(const Program &p)
         // garbage collection for step i
         LOG(Message) << "Garbage collection..." << std::endl;
         env().freeSet(freeProg[i]);
+
+        // Look which temporary objects exist
+        LOG(Debug) << "Remaining temporary objects:" << std::endl;
+        for (unsigned int a = 0; a < env().getMaxAddress(); ++a)
+        {
+            if (env().getObjectStorage(a) == Environment::Storage::temporary)
+            {
+                LOG(Debug) << env().getObjectName(a) << std::endl;
+                env().freeObject(a);
+            }
+        }
+
         // print used memory after garbage collection if necessary
         sizeAfter = env().getTotalSize();
         if (sizeBefore != sizeAfter)

--- a/Hadrons/VirtualMachine.cpp
+++ b/Hadrons/VirtualMachine.cpp
@@ -1032,13 +1032,12 @@ void VirtualMachine::executeProgram(const Program &p)
         LOG(Message) << "Garbage collection..." << std::endl;
         env().freeSet(freeProg[i]);
 
-        // Look which temporary objects exist
-        LOG(Debug) << "Remaining temporary objects:" << std::endl;
+        // Clean up remaining temporary objects
         for (unsigned int a = 0; a < env().getMaxAddress(); ++a)
         {
-            if (env().getObjectStorage(a) == Environment::Storage::temporary)
+            if (env().getObjectStorage(a) == Environment::Storage::temporary
+                and env().hasCreatedObject(a))
             {
-                LOG(Debug) << env().getObjectName(a) << std::endl;
                 env().freeObject(a);
             }
         }


### PR DESCRIPTION
This PR adds an additional garbage collection step after every module, ensuring that all temporary objects are freed. This step is necessary for the naive scheduler which skips the memory profiling step (which is very costly for some GPU workflows) and thus does not know about the temporary objects before running the individual modules. When using the genetic scheduler the additional step does nothing.