### PR TITLE
Implement file bundling in remaining modules

### DIFF
--- a/Hadrons/DistilMatrix.hpp
+++ b/Hadrons/DistilMatrix.hpp
@@ -406,7 +406,7 @@ class DmfComputation
 {
 public:
     FERM_TYPE_ALIASES(FImpl,);
-    typedef DistillationNoise<FImpl> DistillationNoise;
+    typedef Hadrons::DistillationNoise<FImpl> DistillationNoise;
     typedef std::vector<FermionField> DistilVector;
     typedef typename DistillationNoise::Index Index;
     typedef typename DistillationNoise::LapPack LapPack;

--- a/Hadrons/Global.hpp
+++ b/Hadrons/Global.hpp
@@ -144,7 +144,7 @@ typedef typename GImpl::GaugeLinkField GaugeLinkField##suffix;\
 typedef typename Grid::SU<ct_sqrt<sizeof(typename GaugeLinkField::scalar_object)/sizeof(typename GImpl::Scalar)>::value> Group;
 
 #define SOLVER_TYPE_ALIASES(FImpl, suffix)\
-typedef Solver<FImpl> Solver##suffix;
+typedef Hadrons::Solver<FImpl> Solver##suffix;
 
 #define SINK_TYPE_ALIASES(suffix)\
 typedef std::function<SlicedPropagator##suffix\

--- a/Hadrons/Makefile.am
+++ b/Hadrons/Makefile.am
@@ -6,13 +6,13 @@ include modules.inc
 
 libHadrons_a_SOURCES = \
 	sqlite/sqlite3.c    \
-  Application.cpp     \
+ 	Application.cpp     \
 	Database.cpp        \
-  Environment.cpp     \
+ 	Environment.cpp     \
 	Exceptions.cpp      \
-  Global.cpp          \
+ 	Global.cpp          \
 	StatLogger.cpp      \
-  Module.cpp		      \
+ 	Module.cpp		      \
 	TimerArray.cpp      \
 	VirtualMachine.cpp  \
 	$(modules_cpp)
@@ -39,7 +39,8 @@ nobase_libHadrons_a_HEADERS = \
 	Module.hpp                \
 	Modules.hpp               \
 	ModuleFactory.hpp         \
-  NamedTensor.hpp           \
+	NamedTensor.hpp           \
+	Serialization.hpp         \
 	Solver.hpp                \
 	SqlEntry.hpp              \
 	StatLogger.hpp            \

--- a/Hadrons/Modules/MContraction/Baryon.hpp
+++ b/Hadrons/Modules/MContraction/Baryon.hpp
@@ -34,6 +34,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Grid/qcd/utils/BaryonUtils.h>
 
 BEGIN_HADRONS_NAMESPACE
@@ -136,7 +137,7 @@ std::vector<std::string> TBaryon<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TBaryon<FImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
     
     return out;
 }
@@ -216,6 +217,7 @@ void TBaryon<FImpl>::setup(void)
         envTmpLat(LatticeComplex, "c");
     else 
         envTmpLat(SpinMatrixField, "cMat");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -491,9 +493,17 @@ void TBaryon<FImpl>::execute(void)
     }
 
     if (par().trace)
+    {
         saveResult(par().output, "baryon", result);
+        auto &out = envGet(HadronsSerializable, getName());
+        out = result;
+    }
     else 
+    {
         saveResult(par().output + "_Matrix", "baryonMat", resultMat);
+        auto &out = envGet(HadronsSerializable, getName());
+        out = resultMat;
+    }
 
 }
 

--- a/Hadrons/Modules/MContraction/Baryon.hpp
+++ b/Hadrons/Modules/MContraction/Baryon.hpp
@@ -146,10 +146,13 @@ std::vector<std::string> TBaryon<FImpl>::getOutputFiles(void)
 {
     std::vector<std::string> output;
 
-    if (par().trace)
-        output.push_back( resultFilename(par().output) );
-    else 
-        output.push_back( resultFilename(par().output+"_Matrix") );
+    if (!par().output.empty())
+    {
+        if (par().trace)
+            output.push_back( resultFilename(par().output) );
+        else 
+            output.push_back( resultFilename(par().output+"_Matrix") );
+    }
     
     return output;
 }

--- a/Hadrons/Modules/MContraction/BaryonGamma3pt.hpp
+++ b/Hadrons/Modules/MContraction/BaryonGamma3pt.hpp
@@ -32,6 +32,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Grid/qcd/utils/BaryonUtils.h>
 
 BEGIN_HADRONS_NAMESPACE
@@ -203,7 +204,7 @@ std::vector<std::string> TBaryonGamma3pt<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TBaryonGamma3pt<FImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
     
     return out;
 }
@@ -235,6 +236,7 @@ void TBaryonGamma3pt<FImpl>::setup(void)
     envTmpLat(SpinMatrixField, "c");
     envTmpLat(LatticeComplex, "coor");
     envCacheLat(LatticeComplex, momphName_);
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 template <typename FImpl>
@@ -506,6 +508,8 @@ void TBaryonGamma3pt<FImpl>::execute(void)
     }
 
     saveResult(par().output, "baryongamma3pt", result);
+    auto &out = envGet(HadronsSerializable, getName());
+    out = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MContraction/BaryonGamma3pt.hpp
+++ b/Hadrons/Modules/MContraction/BaryonGamma3pt.hpp
@@ -211,7 +211,10 @@ std::vector<std::string> TBaryonGamma3pt<FImpl>::getOutput(void)
 template <typename FImpl>
 std::vector<std::string> TBaryonGamma3pt<FImpl>::getOutputFiles(void)
 {
-    std::vector<std::string> output = {resultFilename(par().output)};
+    std::vector<std::string> output;
+    
+    if (!par().output.empty())
+        output.push_back( resultFilename(par().output) );
     
     return output;
 }

--- a/Hadrons/Modules/MContraction/DiscLoop.hpp
+++ b/Hadrons/Modules/MContraction/DiscLoop.hpp
@@ -130,7 +130,10 @@ std::vector<std::string> TDiscLoop<FImpl>::getOutput(void)
 template <typename FImpl>
 std::vector<std::string> TDiscLoop<FImpl>::getOutputFiles(void)
 {
-    std::vector<std::string> output = {resultFilename(par().output)};
+    std::vector<std::string> output;
+    
+    if (!par().output.empty())
+        output.push_back(resultFilename(par().output));
     
     return output;
 }

--- a/Hadrons/Modules/MContraction/DiscLoop.hpp
+++ b/Hadrons/Modules/MContraction/DiscLoop.hpp
@@ -32,6 +32,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 
 BEGIN_HADRONS_NAMESPACE
 
@@ -121,7 +122,7 @@ std::vector<std::string> TDiscLoop<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TDiscLoop<FImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
     
     return out;
 }
@@ -155,6 +156,7 @@ void TDiscLoop<FImpl>::setup(void)
     }
     envTmpLat(PropagatorField, "ftBuf");
     envTmpLat(PropagatorField, "op");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 template <typename FImpl>
@@ -243,6 +245,8 @@ void TDiscLoop<FImpl>::execute(void)
         }
     }
     saveResult(par().output, "disc", result);
+    auto &out = envGet(HadronsSerializable, getName());
+    out = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MContraction/Gamma3pt.hpp
+++ b/Hadrons/Modules/MContraction/Gamma3pt.hpp
@@ -142,7 +142,10 @@ std::vector<std::string> TGamma3pt<FImpl1, FImpl2, FImpl3>::getOutput(void)
 template <typename FImpl1, typename FImpl2, typename FImpl3>
 std::vector<std::string> TGamma3pt<FImpl1, FImpl2, FImpl3>::getOutputFiles(void)
 {
-    std::vector<std::string> output = {resultFilename(par().output)};
+    std::vector<std::string> output;
+    
+    if (!par().output.empty())
+        output.push_back(resultFilename(par().output));
     
     return output;
 }

--- a/Hadrons/Modules/MContraction/Gamma3pt.hpp
+++ b/Hadrons/Modules/MContraction/Gamma3pt.hpp
@@ -32,6 +32,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 
 BEGIN_HADRONS_NAMESPACE
 
@@ -133,7 +134,7 @@ std::vector<std::string> TGamma3pt<FImpl1, FImpl2, FImpl3>::getInput(void)
 template <typename FImpl1, typename FImpl2, typename FImpl3>
 std::vector<std::string> TGamma3pt<FImpl1, FImpl2, FImpl3>::getOutput(void)
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
     
     return out;
 }
@@ -151,6 +152,7 @@ template <typename FImpl1, typename FImpl2, typename FImpl3>
 void TGamma3pt<FImpl1, FImpl2, FImpl3>::setup(void)
 {
     envTmpLat(LatticeComplex, "c");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 template <typename FImpl1, typename FImpl2, typename FImpl3>
@@ -216,6 +218,8 @@ void TGamma3pt<FImpl1, FImpl2, FImpl3>::execute(void)
         }
     }
     saveResult(par().output, "gamma3pt", result);
+    auto &out = envGet(HadronsSerializable, getName());
+    out = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MContraction/Meson.hpp
+++ b/Hadrons/Modules/MContraction/Meson.hpp
@@ -161,7 +161,10 @@ std::vector<std::string> TMeson<FImpl1, FImpl2>::getOutput(void)
 template <typename FImpl1, typename FImpl2>
 std::vector<std::string> TMeson<FImpl1, FImpl2>::getOutputFiles(void)
 {
-    std::vector<std::string> output = {resultFilename(par().output)};
+    std::vector<std::string> output;
+    
+    if (!par().output.empty())
+        output.push_back(resultFilename(par().output));
     
     return output;
 }

--- a/Hadrons/Modules/MContraction/RareKaonNeutralDisc.hpp
+++ b/Hadrons/Modules/MContraction/RareKaonNeutralDisc.hpp
@@ -32,6 +32,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 
 BEGIN_HADRONS_NAMESPACE
 
@@ -146,7 +147,7 @@ std::vector<std::string> TRareKaonNeutralDisc<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TRareKaonNeutralDisc<FImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
     
     return out;
 }
@@ -164,6 +165,7 @@ template <typename FImpl>
 void TRareKaonNeutralDisc<FImpl>::setup(void)
 {
     envTmpLat(ComplexField, "corr");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -212,6 +214,8 @@ void TRareKaonNeutralDisc<FImpl>::execute(void)
     }
     // IO
     saveResult(par().output, "RK_disc0", result);
+    auto &out = envGet(HadronsSerializable, getName());
+    out = result;
 }
 
 

--- a/Hadrons/Modules/MContraction/RareKaonNeutralDisc.hpp
+++ b/Hadrons/Modules/MContraction/RareKaonNeutralDisc.hpp
@@ -155,7 +155,10 @@ std::vector<std::string> TRareKaonNeutralDisc<FImpl>::getOutput(void)
 template <typename FImpl>
 std::vector<std::string> TRareKaonNeutralDisc<FImpl>::getOutputFiles(void)
 {
-    std::vector<std::string> output = {resultFilename(par().output)};
+    std::vector<std::string> output;
+    
+    if (!par().output.empty())
+        output.push_back(resultFilename(par().output));
     
     return output;
 }

--- a/Hadrons/Modules/MContraction/SigmaToNucleonEye.hpp
+++ b/Hadrons/Modules/MContraction/SigmaToNucleonEye.hpp
@@ -33,6 +33,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Grid/qcd/utils/BaryonUtils.h>
 
 BEGIN_HADRONS_NAMESPACE
@@ -143,7 +144,7 @@ std::vector<std::string> TSigmaToNucleonEye<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TSigmaToNucleonEye<FImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
     
     return out;
 }
@@ -160,6 +161,7 @@ template <typename FImpl>
 void TSigmaToNucleonEye<FImpl>::setup(void)
 {
     envTmpLat(SpinMatrixField, "c");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -216,6 +218,8 @@ void TSigmaToNucleonEye<FImpl>::execute(void)
     }
 
     saveResult(par().output, "stnEye", result);
+    auto &out = envGet(HadronsSerializable, getName());
+    out = result;
 
 }
 

--- a/Hadrons/Modules/MContraction/SigmaToNucleonEye.hpp
+++ b/Hadrons/Modules/MContraction/SigmaToNucleonEye.hpp
@@ -151,7 +151,10 @@ std::vector<std::string> TSigmaToNucleonEye<FImpl>::getOutput(void)
 template <typename FImpl>
 std::vector<std::string> TSigmaToNucleonEye<FImpl>::getOutputFiles(void)
 {
-    std::vector<std::string> output = {resultFilename(par().output)};
+    std::vector<std::string> output;
+    
+    if (!par().output.empty())
+        output.push_back(resultFilename(par().output));
     
     return output;
 }

--- a/Hadrons/Modules/MContraction/SigmaToNucleonNonEye.hpp
+++ b/Hadrons/Modules/MContraction/SigmaToNucleonNonEye.hpp
@@ -33,6 +33,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Grid/qcd/utils/BaryonUtils.h>
 
 BEGIN_HADRONS_NAMESPACE
@@ -148,7 +149,7 @@ std::vector<std::string> TSigmaToNucleonNonEye<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TSigmaToNucleonNonEye<FImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
     
     return out;
 }
@@ -165,6 +166,7 @@ template <typename FImpl>
 void TSigmaToNucleonNonEye<FImpl>::setup(void)
 {
     envTmpLat(SpinMatrixField, "c");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -222,6 +224,8 @@ void TSigmaToNucleonNonEye<FImpl>::execute(void)
     }
 
     saveResult(par().output, "stnNonEye", result);
+    auto &out = envGet(HadronsSerializable, getName());
+    out = result;
 
 }
 

--- a/Hadrons/Modules/MContraction/SigmaToNucleonNonEye.hpp
+++ b/Hadrons/Modules/MContraction/SigmaToNucleonNonEye.hpp
@@ -156,7 +156,10 @@ std::vector<std::string> TSigmaToNucleonNonEye<FImpl>::getOutput(void)
 template <typename FImpl>
 std::vector<std::string> TSigmaToNucleonNonEye<FImpl>::getOutputFiles(void)
 {
-    std::vector<std::string> output = {resultFilename(par().output)};
+    std::vector<std::string> output;
+    
+    if (!par().output.empty())
+        output.push_back(resultFilename(par().output));
     
     return output;
 }

--- a/Hadrons/Modules/MContraction/WardIdentity.hpp
+++ b/Hadrons/Modules/MContraction/WardIdentity.hpp
@@ -94,6 +94,7 @@ public:
     // dependency relation
     virtual std::vector<std::string> getInput(void);
     virtual std::vector<std::string> getOutput(void);
+    virtual std::vector<std::string> getOutputFiles(void);
 protected:
     // setup
     virtual void setup(void);
@@ -138,6 +139,17 @@ std::vector<std::string> TWardIdentity<FImpl>::getOutput(void)
     std::vector<std::string> out = {getName()};
     
     return out;
+}
+
+template <typename FImpl>
+std::vector<std::string> TWardIdentity<FImpl>::getOutputFiles(void)
+{
+    std::vector<std::string> output;
+    
+    if (!par().output.empty())
+        output.push_back(resultFilename(par().output));
+    
+    return output;
 }
 
 // setup ///////////////////////////////////////////////////////////////////////

--- a/Hadrons/Modules/MContraction/WardIdentity.hpp
+++ b/Hadrons/Modules/MContraction/WardIdentity.hpp
@@ -33,6 +33,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 
 BEGIN_HADRONS_NAMESPACE
 
@@ -134,7 +135,9 @@ std::vector<std::string> TWardIdentity<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TWardIdentity<FImpl>::getOutput(void)
 {
-  return {};
+    std::vector<std::string> out = {getName()};
+    
+    return out;
 }
 
 // setup ///////////////////////////////////////////////////////////////////////
@@ -155,6 +158,7 @@ void TWardIdentity<FImpl>::setup(void)
     // These temporaries are always 4d
     envTmpLat(PropagatorField, "tmp");
     envTmpLat(ComplexField, "tmp_current");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -223,6 +227,8 @@ void TWardIdentity<FImpl>::execute(void)
 
     LOG(Message) << "Writing results to " << par().output << "." << std::endl;
     saveResult(par().output, "wardIdentity", result);
+    auto &out = envGet(HadronsSerializable, getName());
+    out = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MContraction/WeakEye3pt.hpp
+++ b/Hadrons/Modules/MContraction/WeakEye3pt.hpp
@@ -33,6 +33,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 
 BEGIN_HADRONS_NAMESPACE
 
@@ -128,7 +129,7 @@ std::vector<std::string> TWeakEye3pt<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TWeakEye3pt<FImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
     
     return out;
 }
@@ -146,6 +147,7 @@ template <typename FImpl>
 void TWeakEye3pt<FImpl>::setup(void)
 {
     envTmpLat(ComplexField, "corr");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -201,6 +203,8 @@ void TWeakEye3pt<FImpl>::execute(void)
         result.push_back(r);
     }
     saveResult(par().output, "weakEye3pt", result);
+    auto &out = envGet(HadronsSerializable, getName());
+    out = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MContraction/WeakEye3pt.hpp
+++ b/Hadrons/Modules/MContraction/WeakEye3pt.hpp
@@ -137,7 +137,10 @@ std::vector<std::string> TWeakEye3pt<FImpl>::getOutput(void)
 template <typename FImpl>
 std::vector<std::string> TWeakEye3pt<FImpl>::getOutputFiles(void)
 {
-    std::vector<std::string> output = {resultFilename(par().output)};
+    std::vector<std::string> output;
+    
+    if (!par().output.empty())
+        output.push_back(resultFilename(par().output));
     
     return output;
 }

--- a/Hadrons/Modules/MContraction/WeakMesonDecayKl2.hpp
+++ b/Hadrons/Modules/MContraction/WeakMesonDecayKl2.hpp
@@ -138,7 +138,10 @@ std::vector<std::string> TWeakMesonDecayKl2<FImpl>::getOutput(void)
 template <typename FImpl>
 std::vector<std::string> TWeakMesonDecayKl2<FImpl>::getOutputFiles(void)
 {
-    std::vector<std::string> output = {resultFilename(par().output)};
+    std::vector<std::string> output;
+    
+    if (!par().output.empty())
+        output.push_back(resultFilename(par().output));
     
     return output;
 }

--- a/Hadrons/Modules/MContraction/WeakMesonDecayKl2.hpp
+++ b/Hadrons/Modules/MContraction/WeakMesonDecayKl2.hpp
@@ -34,6 +34,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 
 BEGIN_HADRONS_NAMESPACE
 
@@ -129,7 +130,7 @@ std::vector<std::string> TWeakMesonDecayKl2<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TWeakMesonDecayKl2<FImpl>::getOutput(void)
 {
-    std::vector<std::string> output = {};
+    std::vector<std::string> output = {getName()};
     
     return output;
 }
@@ -150,6 +151,7 @@ void TWeakMesonDecayKl2<FImpl>::setup(void)
     envTmpLat(PropagatorField, "prop_buf");
     envCreateLat(PropagatorField, getName());
     envTmpLat(SpinMatrixField, "buf");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -185,6 +187,8 @@ void TWeakMesonDecayKl2<FImpl>::execute(void)
     buf = peekColour(res, 0, 0);
     sliceSum(buf, r.corr, Tp);
     saveResult(par().output, "weakdecay", r);
+    auto &out = envGet(HadronsSerializable, getName());
+    out = r;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MContraction/WeakNonEye3pt.hpp
+++ b/Hadrons/Modules/MContraction/WeakNonEye3pt.hpp
@@ -136,7 +136,10 @@ std::vector<std::string> TWeakNonEye3pt<FImpl>::getOutput(void)
 template <typename FImpl>
 std::vector<std::string> TWeakNonEye3pt<FImpl>::getOutputFiles(void)
 {
-    std::vector<std::string> output = {resultFilename(par().output)};
+    std::vector<std::string> output;
+    
+    if (!par().output.empty())
+        output.push_back(resultFilename(par().output));
     
     return output;
 }

--- a/Hadrons/Modules/MContraction/XiToSigmaEye.hpp
+++ b/Hadrons/Modules/MContraction/XiToSigmaEye.hpp
@@ -152,7 +152,10 @@ std::vector<std::string> TXiToSigmaEye<FImpl>::getOutput(void)
 template <typename FImpl>
 std::vector<std::string> TXiToSigmaEye<FImpl>::getOutputFiles(void)
 {
-    std::vector<std::string> output = {resultFilename(par().output)};
+    std::vector<std::string> output;
+    
+    if (!par().output.empty())
+        output.push_back(resultFilename(par().output));
     
     return output;
 }

--- a/Hadrons/Modules/MContraction/XiToSigmaEye.hpp
+++ b/Hadrons/Modules/MContraction/XiToSigmaEye.hpp
@@ -33,6 +33,7 @@
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
 #include <Grid/qcd/utils/BaryonUtils.h>
+#include <Hadrons/Serialization.hpp>
 
 BEGIN_HADRONS_NAMESPACE
 
@@ -144,7 +145,7 @@ std::vector<std::string> TXiToSigmaEye<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TXiToSigmaEye<FImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
     
     return out;
 }
@@ -161,6 +162,7 @@ template <typename FImpl>
 void TXiToSigmaEye<FImpl>::setup(void)
 {
     envTmpLat(SpinMatrixField, "c");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -219,6 +221,8 @@ void TXiToSigmaEye<FImpl>::execute(void)
     }
 
     saveResult(par().output, "xtsEye", result);
+    auto &out = envGet(HadronsSerializable, getName());
+    out = result;
 
 }
 

--- a/Hadrons/Modules/MFermion/FreeProp.hpp
+++ b/Hadrons/Modules/MFermion/FreeProp.hpp
@@ -81,6 +81,7 @@ public:
     // dependency relation
     virtual std::vector<std::string> getInput(void);
     virtual std::vector<std::string> getOutput(void);
+    virtual std::vector<std::string> getOutputFiles(void);
 protected:
     // setup
     virtual void setup(void);
@@ -116,6 +117,17 @@ std::vector<std::string> TFreeProp<FImpl>::getOutput(void)
     std::vector<std::string> out = {getName(), getName() + "_5d"};
     
     return out;
+}
+
+template <typename FImpl>
+std::vector<std::string> TFreeProp<FImpl>::getOutputFiles(void)
+{
+    std::vector<std::string> output;
+    
+    if (!par().outputTrace.empty())
+        output.push_back(resultFilename(par().outputTrace));
+    
+    return output;
 }
 
 // setup ///////////////////////////////////////////////////////////////////////

--- a/Hadrons/Modules/MIO/CorrelatorGroup.hpp
+++ b/Hadrons/Modules/MIO/CorrelatorGroup.hpp
@@ -47,7 +47,8 @@ public:
                                     std::vector<std::string>, contractions);
 };
 
-template<typename Impl>
+// Placeholder template argument required by MODULE_REGISTER_TMP
+template<typename Placeholder>
 class TCorrelatorGroup: public Module<CorrelatorGroupPar>
 {
 public:
@@ -71,28 +72,28 @@ MODULE_REGISTER_TMP(CorrelatorGroup, TCorrelatorGroup<FIMPL>, MIO);
  *                 TCorrelatorGroup implementation                            *
  ******************************************************************************/
 // constructor /////////////////////////////////////////////////////////////////
-template <typename Impl>
-TCorrelatorGroup<Impl>::TCorrelatorGroup(const std::string name)
+template <typename Placeholder>
+TCorrelatorGroup<Placeholder>::TCorrelatorGroup(const std::string name)
 : Module<CorrelatorGroupPar>(name)
 {}
 
 // dependencies/products ///////////////////////////////////////////////////////
-template<typename Impl>
-std::vector<std::string> TCorrelatorGroup<Impl>::getInput(void)
+template<typename Placeholder>
+std::vector<std::string> TCorrelatorGroup<Placeholder>::getInput(void)
 {
     return par().contractions;
 }
 
-template<typename Impl>
-std::vector<std::string> TCorrelatorGroup<Impl>::getOutput(void)
+template<typename Placeholder>
+std::vector<std::string> TCorrelatorGroup<Placeholder>::getOutput(void)
 {
     std::vector<std::string> output = {getName()};
     
     return output;
 }
 
-template<typename Impl>
-std::vector<std::string> TCorrelatorGroup<Impl>::getOutputFiles(void)
+template<typename Placeholder>
+std::vector<std::string> TCorrelatorGroup<Placeholder>::getOutputFiles(void)
 {
     std::vector<std::string> out = {};
     
@@ -100,16 +101,17 @@ std::vector<std::string> TCorrelatorGroup<Impl>::getOutputFiles(void)
 }
 
 // setup ///////////////////////////////////////////////////////////////////////
-template<typename Impl>
-void TCorrelatorGroup<Impl>::setup(void)
+template<typename Placeholder>
+void TCorrelatorGroup<Placeholder>::setup(void)
 {
     envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
-template<typename Impl>
-void TCorrelatorGroup<Impl>::execute(void)
+template<typename Placeholder>
+void TCorrelatorGroup<Placeholder>::execute(void)
 {
+    LOG(Message) << "Starting result collation into Result Group '" << getName() << "'..." << std::endl;
     auto &contractionList = par().contractions;
     auto &out             = envGet(HadronsSerializable, getName());
     auto &result          = out.template hold<HadronsSerializableGroup>(contractionList.size());
@@ -118,7 +120,9 @@ void TCorrelatorGroup<Impl>::execute(void)
     {
         auto &moduleResults = envGet(HadronsSerializable, contractionModuleName);
         result.append(contractionModuleName, moduleResults);
+        LOG(Message) << "Bundled '" << contractionModuleName << "' into Result Group '" << getName() << "'." << std::endl;
     }
+    LOG(Message) << "Finished collating results into Result Group '" << getName() << "'." << std::endl;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MIO/ResultGroup.cpp
+++ b/Hadrons/Modules/MIO/ResultGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * CorrelatorGroup.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ * ResultGroup.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
  *
  * Copyright (C) 2015 - 2022
  *
@@ -24,10 +24,10 @@
  */
 
 /*  END LEGAL */
-#include <Hadrons/Modules/MIO/CorrelatorGroup.hpp>
+#include <Hadrons/Modules/MIO/ResultGroup.hpp>
 
 using namespace Grid;
 using namespace Hadrons;
 using namespace MIO;
 
-template class Grid::Hadrons::MIO::TCorrelatorGroup<FIMPL>;
+template class Grid::Hadrons::MIO::TResultGroup<void>;

--- a/Hadrons/Modules/MIO/ResultGroup.hpp
+++ b/Hadrons/Modules/MIO/ResultGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * CorrelatorGroup.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ * ResultGroup.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
  *
  * Copyright (C) 2015 - 2022
  *
@@ -25,8 +25,8 @@
 
 /*  END LEGAL */
 
-#ifndef Hadrons_MIO_CorrelatorGroup_hpp_
-#define Hadrons_MIO_CorrelatorGroup_hpp_
+#ifndef Hadrons_MIO_ResultGroup_hpp_
+#define Hadrons_MIO_ResultGroup_hpp_
 
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
@@ -40,22 +40,22 @@ BEGIN_HADRONS_NAMESPACE
  ******************************************************************************/
 BEGIN_MODULE_NAMESPACE(MIO)
 
-class CorrelatorGroupPar: Serializable
+class ResultGroupPar: Serializable
 {
 public:
-    GRID_SERIALIZABLE_CLASS_MEMBERS(CorrelatorGroupPar,
-                                    std::vector<std::string>, contractions);
+    GRID_SERIALIZABLE_CLASS_MEMBERS(ResultGroupPar,
+                                    std::vector<std::string>, results);
 };
 
 // Placeholder template argument required by MODULE_REGISTER_TMP
 template<typename Placeholder>
-class TCorrelatorGroup: public Module<CorrelatorGroupPar>
+class TResultGroup: public Module<ResultGroupPar>
 {
 public:
     // constructor
-    TCorrelatorGroup(const std::string name);
+    TResultGroup(const std::string name);
     // destructor
-    virtual ~TCorrelatorGroup(void) {};
+    virtual ~TResultGroup(void) {};
     // dependency relation
     virtual std::vector<std::string> getInput(void);
     virtual std::vector<std::string> getOutput(void);
@@ -66,26 +66,26 @@ public:
     virtual void execute(void);
 };
 
-MODULE_REGISTER_TMP(CorrelatorGroup, TCorrelatorGroup<FIMPL>, MIO);
+MODULE_REGISTER_TMP(ResultGroup, TResultGroup<void>, MIO);
 
 /******************************************************************************
- *                 TCorrelatorGroup implementation                            *
+ *                     TResultGroup implementation                            *
  ******************************************************************************/
 // constructor /////////////////////////////////////////////////////////////////
 template <typename Placeholder>
-TCorrelatorGroup<Placeholder>::TCorrelatorGroup(const std::string name)
-: Module<CorrelatorGroupPar>(name)
+TResultGroup<Placeholder>::TResultGroup(const std::string name)
+: Module<ResultGroupPar>(name)
 {}
 
 // dependencies/products ///////////////////////////////////////////////////////
 template<typename Placeholder>
-std::vector<std::string> TCorrelatorGroup<Placeholder>::getInput(void)
+std::vector<std::string> TResultGroup<Placeholder>::getInput(void)
 {
-    return par().contractions;
+    return par().results;
 }
 
 template<typename Placeholder>
-std::vector<std::string> TCorrelatorGroup<Placeholder>::getOutput(void)
+std::vector<std::string> TResultGroup<Placeholder>::getOutput(void)
 {
     std::vector<std::string> output = {getName()};
     
@@ -93,7 +93,7 @@ std::vector<std::string> TCorrelatorGroup<Placeholder>::getOutput(void)
 }
 
 template<typename Placeholder>
-std::vector<std::string> TCorrelatorGroup<Placeholder>::getOutputFiles(void)
+std::vector<std::string> TResultGroup<Placeholder>::getOutputFiles(void)
 {
     std::vector<std::string> out = {};
     
@@ -102,25 +102,25 @@ std::vector<std::string> TCorrelatorGroup<Placeholder>::getOutputFiles(void)
 
 // setup ///////////////////////////////////////////////////////////////////////
 template<typename Placeholder>
-void TCorrelatorGroup<Placeholder>::setup(void)
+void TResultGroup<Placeholder>::setup(void)
 {
     envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
 template<typename Placeholder>
-void TCorrelatorGroup<Placeholder>::execute(void)
+void TResultGroup<Placeholder>::execute(void)
 {
     LOG(Message) << "Starting result collation into Result Group '" << getName() << "'..." << std::endl;
-    auto &contractionList = par().contractions;
-    auto &out             = envGet(HadronsSerializable, getName());
-    auto &result          = out.template hold<HadronsSerializableGroup>(contractionList.size());
+    auto &resultList  = par().results;
+    auto &out         = envGet(HadronsSerializable, getName());
+    auto &resultGroup = out.template hold<HadronsSerializableGroup>(resultList.size());
 
-    for (const auto &contractionModuleName : contractionList)
+    for (const auto &resultName : resultList)
     {
-        auto &moduleResults = envGet(HadronsSerializable, contractionModuleName);
-        result.append(contractionModuleName, moduleResults);
-        LOG(Message) << "Bundled '" << contractionModuleName << "' into Result Group '" << getName() << "'." << std::endl;
+        auto &result = envGet(HadronsSerializable, resultName);
+        resultGroup.append(resultName, result);
+        LOG(Message) << "Bundled '" << resultName << "' into Result Group '" << getName() << "'." << std::endl;
     }
     LOG(Message) << "Finished collating results into Result Group '" << getName() << "'." << std::endl;
 }
@@ -129,4 +129,4 @@ END_MODULE_NAMESPACE
 
 END_HADRONS_NAMESPACE
 
-#endif // Hadrons_MIO_CorrelatorGroup_hpp_
+#endif // Hadrons_MIO_ResultGroup_hpp_

--- a/Hadrons/Modules/MIO/WriteCorrelatorGroup.cpp
+++ b/Hadrons/Modules/MIO/WriteCorrelatorGroup.cpp
@@ -30,4 +30,4 @@ using namespace Grid;
 using namespace Hadrons;
 using namespace MIO;
 
-template class Grid::Hadrons::MIO::TWriteCorrelatorGroup<FIMPL,FIMPL>;
+template class Grid::Hadrons::MIO::TWriteCorrelatorGroup<FIMPL>;

--- a/Hadrons/Modules/MIO/WriteCorrelatorGroup.hpp
+++ b/Hadrons/Modules/MIO/WriteCorrelatorGroup.hpp
@@ -40,6 +40,7 @@ BEGIN_HADRONS_NAMESPACE
  ******************************************************************************/
 BEGIN_MODULE_NAMESPACE(MIO)
 
+// Placeholder template argument required by MODULE_REGISTER_TMP
 class WriteCorrelatorGroupPar: Serializable
 {
 public:
@@ -48,7 +49,7 @@ public:
                                     std::string, output);
 };
 
-template <typename FImpl1, typename FImpl2>
+template <typename Placeholder>
 class TWriteCorrelatorGroup: public Module<WriteCorrelatorGroupPar>
 {
 public:
@@ -66,34 +67,34 @@ public:
     virtual void execute(void);
 };
 
-MODULE_REGISTER_TMP(WriteCorrelatorGroup, ARG(TWriteCorrelatorGroup<FIMPL, FIMPL>), MIO);
+MODULE_REGISTER_TMP(WriteCorrelatorGroup, TWriteCorrelatorGroup<FIMPL>, MIO);
 
 /******************************************************************************
  *                TWriteCorrelators implementation                            *
  ******************************************************************************/
 // constructor /////////////////////////////////////////////////////////////////
-template <typename FImpl1, typename FImpl2>
-TWriteCorrelatorGroup<FImpl1, FImpl2>::TWriteCorrelatorGroup(const std::string name)
+template <typename Placeholder>
+TWriteCorrelatorGroup<Placeholder>::TWriteCorrelatorGroup(const std::string name)
 : Module<WriteCorrelatorGroupPar>(name)
 {}
 
 // dependencies/products ///////////////////////////////////////////////////////
-template <typename FImpl1, typename FImpl2>
-std::vector<std::string> TWriteCorrelatorGroup<FImpl1, FImpl2>::getInput(void)
+template <typename Placeholder>
+std::vector<std::string> TWriteCorrelatorGroup<Placeholder>::getInput(void)
 {
     return par().contractions;
 }
 
-template <typename FImpl1, typename FImpl2>
-std::vector<std::string> TWriteCorrelatorGroup<FImpl1, FImpl2>::getOutput(void)
+template <typename Placeholder>
+std::vector<std::string> TWriteCorrelatorGroup<Placeholder>::getOutput(void)
 {
     std::vector<std::string> out = {};
     
     return out;
 }
 
-template <typename FImpl1, typename FImpl2>
-std::vector<std::string> TWriteCorrelatorGroup<FImpl1, FImpl2>::getOutputFiles(void)
+template <typename Placeholder>
+std::vector<std::string> TWriteCorrelatorGroup<Placeholder>::getOutputFiles(void)
 {
     std::vector<std::string> out = {resultFilename(par().output)};
     
@@ -101,16 +102,17 @@ std::vector<std::string> TWriteCorrelatorGroup<FImpl1, FImpl2>::getOutputFiles(v
 }
 
 // setup ///////////////////////////////////////////////////////////////////////
-template <typename FImpl1, typename FImpl2>
-void TWriteCorrelatorGroup<FImpl1, FImpl2>::setup(void)
+template <typename Placeholder>
+void TWriteCorrelatorGroup<Placeholder>::setup(void)
 {
     
 }
 
 // execution ///////////////////////////////////////////////////////////////////
-template <typename FImpl1, typename FImpl2>
-void TWriteCorrelatorGroup<FImpl1, FImpl2>::execute(void)
+template <typename Placeholder>
+void TWriteCorrelatorGroup<Placeholder>::execute(void)
 {
+    LOG(Message) << "Preparing to write collated results into file '" << par().output << "'..." << std::endl;
     auto &contractionList = par().contractions; // Switch to std::vector with <elem></elem> tags
 
     HadronsSerializableGroup result(contractionList.size());
@@ -118,11 +120,13 @@ void TWriteCorrelatorGroup<FImpl1, FImpl2>::execute(void)
     {
         auto &moduleResults = envGet(HadronsSerializable, contractionModuleName);
         result.append(contractionModuleName, moduleResults);
+        LOG(Message) << "Bundled group '" << contractionModuleName << "' into output." << std::endl;
     }
 
     // Pass a blank string to dump the unpacked group the file, rather than
     // adding a forced and useless outer group around the result
     saveResult(par().output, "", result);
+    LOG(Message) << "Finshed writing collated results into file '" << par().output << "'." << std::endl;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MIO/WriteResultGroup.cpp
+++ b/Hadrons/Modules/MIO/WriteResultGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * WriteCorrelators.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ * WriteResultGroup.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
  *
  * Copyright (C) 2015 - 2022
  *
@@ -24,10 +24,10 @@
  */
 
 /*  END LEGAL */
-#include <Hadrons/Modules/MIO/WriteCorrelatorGroup.hpp>
+#include <Hadrons/Modules/MIO/WriteResultGroup.hpp>
 
 using namespace Grid;
 using namespace Hadrons;
 using namespace MIO;
 
-template class Grid::Hadrons::MIO::TWriteCorrelatorGroup<FIMPL>;
+template class Grid::Hadrons::MIO::TWriteResultGroup<void>;

--- a/Hadrons/Modules/MIO/WriteResultGroup.hpp
+++ b/Hadrons/Modules/MIO/WriteResultGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * WriteCorrelators.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ * WriteResultGroup.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
  *
  * Copyright (C) 2015 - 2022
  *
@@ -25,8 +25,8 @@
 
 /*  END LEGAL */
 
-#ifndef Hadrons_MIO_WriteCorrelators_hpp_
-#define Hadrons_MIO_WriteCorrelators_hpp_
+#ifndef Hadrons_MIO_WriteResultGroup_hpp_
+#define Hadrons_MIO_WriteResultGroup_hpp_
 
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
@@ -41,22 +41,22 @@ BEGIN_HADRONS_NAMESPACE
 BEGIN_MODULE_NAMESPACE(MIO)
 
 // Placeholder template argument required by MODULE_REGISTER_TMP
-class WriteCorrelatorGroupPar: Serializable
+class WriteResultGroupPar: Serializable
 {
 public:
-    GRID_SERIALIZABLE_CLASS_MEMBERS(WriteCorrelatorGroupPar,
-                                    std::vector<std::string>, contractions,
+    GRID_SERIALIZABLE_CLASS_MEMBERS(WriteResultGroupPar,
+                                    std::vector<std::string>, results,
                                     std::string, output);
 };
 
 template <typename Placeholder>
-class TWriteCorrelatorGroup: public Module<WriteCorrelatorGroupPar>
+class TWriteResultGroup: public Module<WriteResultGroupPar>
 {
 public:
     // constructor
-    TWriteCorrelatorGroup(const std::string name);
+    TWriteResultGroup(const std::string name);
     // destructor
-    virtual ~TWriteCorrelatorGroup(void) {};
+    virtual ~TWriteResultGroup(void) {};
     // dependency relation
     virtual std::vector<std::string> getInput(void);
     virtual std::vector<std::string> getOutput(void);
@@ -67,26 +67,26 @@ public:
     virtual void execute(void);
 };
 
-MODULE_REGISTER_TMP(WriteCorrelatorGroup, TWriteCorrelatorGroup<FIMPL>, MIO);
+MODULE_REGISTER_TMP(WriteResultGroup, TWriteResultGroup<void>, MIO);
 
 /******************************************************************************
- *                TWriteCorrelators implementation                            *
+ *                TWriteResultGroup implementation                            *
  ******************************************************************************/
 // constructor /////////////////////////////////////////////////////////////////
 template <typename Placeholder>
-TWriteCorrelatorGroup<Placeholder>::TWriteCorrelatorGroup(const std::string name)
-: Module<WriteCorrelatorGroupPar>(name)
+TWriteResultGroup<Placeholder>::TWriteResultGroup(const std::string name)
+: Module<WriteResultGroupPar>(name)
 {}
 
 // dependencies/products ///////////////////////////////////////////////////////
 template <typename Placeholder>
-std::vector<std::string> TWriteCorrelatorGroup<Placeholder>::getInput(void)
+std::vector<std::string> TWriteResultGroup<Placeholder>::getInput(void)
 {
-    return par().contractions;
+    return par().results;
 }
 
 template <typename Placeholder>
-std::vector<std::string> TWriteCorrelatorGroup<Placeholder>::getOutput(void)
+std::vector<std::string> TWriteResultGroup<Placeholder>::getOutput(void)
 {
     std::vector<std::string> out = {};
     
@@ -94,7 +94,7 @@ std::vector<std::string> TWriteCorrelatorGroup<Placeholder>::getOutput(void)
 }
 
 template <typename Placeholder>
-std::vector<std::string> TWriteCorrelatorGroup<Placeholder>::getOutputFiles(void)
+std::vector<std::string> TWriteResultGroup<Placeholder>::getOutputFiles(void)
 {
     std::vector<std::string> out = {resultFilename(par().output)};
     
@@ -103,29 +103,29 @@ std::vector<std::string> TWriteCorrelatorGroup<Placeholder>::getOutputFiles(void
 
 // setup ///////////////////////////////////////////////////////////////////////
 template <typename Placeholder>
-void TWriteCorrelatorGroup<Placeholder>::setup(void)
+void TWriteResultGroup<Placeholder>::setup(void)
 {
     
 }
 
 // execution ///////////////////////////////////////////////////////////////////
 template <typename Placeholder>
-void TWriteCorrelatorGroup<Placeholder>::execute(void)
+void TWriteResultGroup<Placeholder>::execute(void)
 {
     LOG(Message) << "Preparing to write collated results into file '" << par().output << "'..." << std::endl;
-    auto &contractionList = par().contractions; // Switch to std::vector with <elem></elem> tags
+    auto &resultList = par().results; // Switch to std::vector with <elem></elem> tags
 
-    HadronsSerializableGroup result(contractionList.size());
-    for (const auto &contractionModuleName : contractionList)
+    HadronsSerializableGroup resultGroup(resultList.size());
+    for (const auto &resultName : resultList)
     {
-        auto &moduleResults = envGet(HadronsSerializable, contractionModuleName);
-        result.append(contractionModuleName, moduleResults);
-        LOG(Message) << "Bundled group '" << contractionModuleName << "' into output." << std::endl;
+        auto &result = envGet(HadronsSerializable, resultName);
+        resultGroup.append(resultName, result);
+        LOG(Message) << "Bundled group '" << resultName << "' into output." << std::endl;
     }
 
     // Pass a blank string to dump the unpacked group the file, rather than
     // adding a forced and useless outer group around the result
-    saveResult(par().output, "", result);
+    saveResult(par().output, "", resultGroup);
     LOG(Message) << "Finshed writing collated results into file '" << par().output << "'." << std::endl;
 }
 
@@ -133,4 +133,4 @@ END_MODULE_NAMESPACE
 
 END_HADRONS_NAMESPACE
 
-#endif // Hadrons_MIO_WriteCorrelators_hpp_
+#endif // Hadrons_MIO_WriteResultGroup_hpp_

--- a/Hadrons/Modules/MNPR/Bilinear.hpp
+++ b/Hadrons/Modules/MNPR/Bilinear.hpp
@@ -34,6 +34,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Hadrons/Modules/MNPR/NPRUtils.hpp>
 
 BEGIN_HADRONS_NAMESPACE
@@ -124,6 +125,8 @@ void TBilinear<FImpl>::setup(void)
     envTmpLat(ComplexField, "pDotXIn");
     envTmpLat(ComplexField, "pDotXOut");
     envTmpLat(ComplexField, "xMu");
+
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // dependencies/products ///////////////////////////////////////////////////////
@@ -138,7 +141,7 @@ std::vector<std::string> TBilinear<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TBilinear<FImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
 
     return out;
 }
@@ -200,8 +203,10 @@ void TBilinear<FImpl>::execute(void)
     }
 
     //////////////////////////////////////////////////
-    saveResult(par().output, "Bilinear", result);
     LOG(Message) << "Complete. Writing results to " << par().output << std::endl;
+    saveResult(par().output, "Bilinear", result);
+    auto& out = envGet(HadronsSerializable, getName());
+    out = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MNPR/ExternalLeg.hpp
+++ b/Hadrons/Modules/MNPR/ExternalLeg.hpp
@@ -35,6 +35,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Hadrons/Modules/MNPR/NPRUtils.hpp>
 
 BEGIN_HADRONS_NAMESPACE
@@ -102,6 +103,8 @@ void TExternalLeg<FImpl>::setup(void)
     envTmpLat(PropagatorField, "qIn_phased");
     envTmpLat(ComplexField, "pDotXIn");
     envTmpLat(ComplexField, "xMu");
+
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // dependencies/products ///////////////////////////////////////////////////////
@@ -116,7 +119,7 @@ std::vector<std::string> TExternalLeg<FImpl>::getInput(void)
 template <typename FImpl>
 std::vector<std::string> TExternalLeg<FImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
 
     return out;
 }
@@ -158,8 +161,10 @@ void TExternalLeg<FImpl>::execute(void)
     r.info.pIn  = par().pIn;
     r.corr.push_back( (1.0 / volume) * sum(qIn_phased) );
 
-    saveResult(par().output, "ExternalLeg", r);
     LOG(Message) << "Complete. Writing results to " << par().output << std:: endl;
+    saveResult(par().output, "ExternalLeg", r);
+    auto& out = envGet(HadronsSerializable, getName());
+    out = r;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MNPR/FourQuarkFullyConnected.hpp
+++ b/Hadrons/Modules/MNPR/FourQuarkFullyConnected.hpp
@@ -35,6 +35,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Hadrons/Modules/MNPR/NPRUtils.hpp>
 
 BEGIN_HADRONS_NAMESPACE
@@ -100,7 +101,7 @@ std::vector<std::string> TFourQuarkFullyConnected<FImpl>::getInput()
 template <typename FImpl>
 std::vector<std::string> TFourQuarkFullyConnected<FImpl>::getOutput()
 {
-    std::vector<std::string> out = {};
+    std::vector<std::string> out = {getName()};
 
     return out;
 }
@@ -122,8 +123,9 @@ void TFourQuarkFullyConnected<FImpl>::setup()
     envTmpLat(PropagatorField, "bilinear");
     envTmpLat(PropagatorField, "bilinear_tmp");
     envTmpLat(SpinColourSpinColourMatrixField, "lret");
-
     envTmpLat(ComplexField, "bilinear_phase");
+
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 template <typename FImpl>
@@ -247,8 +249,10 @@ void TFourQuarkFullyConnected<FImpl>::execute()
             << std::endl;
     }
 
-    saveResult(par().output, "FourQuarkFullyConnected", result);
     LOG(Message) << "Complete. Writing results to " << par().output << std::endl;
+    saveResult(par().output, "FourQuarkFullyConnected", result);
+    auto& out = envGet(HadronsSerializable, getName());
+    out = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MNPR/FourQuarkLoop.hpp
+++ b/Hadrons/Modules/MNPR/FourQuarkLoop.hpp
@@ -32,6 +32,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Hadrons/Modules/MNPR/NPRUtils.hpp>
 
 
@@ -189,7 +190,7 @@ std::vector<std::string> TFourQuarkLoop<FImpl>::getInput()
 template <typename FImpl>
 std::vector<std::string> TFourQuarkLoop<FImpl>::getOutput()
 {
-    std::vector<std::string> out = {getName()};
+    std::vector<std::string> out = {getName(), getName() + "_fourQuark", getName() + "_twoQuark"};
 
     return out;
 }
@@ -220,6 +221,9 @@ void TFourQuarkLoop<FImpl>::setup()
     {
         envTmpLat(ComplexField, "loop_trace");
     }
+
+    envCreate(HadronsSerializable, getName() + "_fourQuark", 1, 0);
+    envCreate(HadronsSerializable, getName() + "_twoQuark", 1, 0);
 }
 
 template <typename FImpl>
@@ -414,6 +418,8 @@ void TFourQuarkLoop<FImpl>::execute()
     LOG(Message) << "Done computing loop diagrams" << std::endl;
     saveResult(par().output + "_fourQuark", "FourQuarkLoop", fourq_result);
     saveResult(par().output + "_twoQuark", "TwoQuarkLoop", twoq_result);
+    envGet(HadronsSerializable, getName() + "_fourQuark") = fourq_result;
+    envGet(HadronsSerializable, getName() + "_twoQuark") = twoq_result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MNPR/G1.hpp
+++ b/Hadrons/Modules/MNPR/G1.hpp
@@ -32,6 +32,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Hadrons/Modules/MNPR/NPRUtils.hpp>
 
 BEGIN_HADRONS_NAMESPACE
@@ -125,11 +126,11 @@ void TG1<FImpl>::setup(void)
     LOG(Message) << "Running setup for G1" << std::endl;
 
     envTmpLat(PropagatorField, "bilinear");
-
     envTmpLat(ComplexField, "bilinear_phase");
-
     envTmpLat(GaugeField, "dSdU");
     envTmpLat(ColourMatrixField, "div_field_strength");
+
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -212,8 +213,10 @@ void TG1<FImpl>::execute(void)
         bilinear = bilinear_phase * bilinear;
         result.fourq_gamma5 += (1.0 / volume) * sum(bilinear);
     }
-    saveResult(par().output, "G1", result);
+
     LOG(Message) << "Complete. Writing results to " << par().output << std::endl;
+    saveResult(par().output, "G1", result);
+    envGet(HadronsSerializable, getName()) = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MNPR/SubtractionOperators.hpp
+++ b/Hadrons/Modules/MNPR/SubtractionOperators.hpp
@@ -32,6 +32,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Hadrons/Modules/MNPR/NPRUtils.hpp>
 
 BEGIN_HADRONS_NAMESPACE
@@ -144,6 +145,8 @@ void TSubtractionOperators<FImpl>::setup(void)
     envTmpLat(ComplexField, "coordinate");
 
     envTmpLat(PropagatorField, "tmp");
+
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -234,10 +237,9 @@ void TSubtractionOperators<FImpl>::execute(void)
     bilinear = g5 * adj(qOut) * qIn;
     compute_result(result.psuedoscalar);
 
-    if (par().output != "") {
-        saveResult(par().output, "SubtractionOperators", result);
-        LOG(Message) << "Complete. Writing results to " << par().output << std::endl;
-    }
+    LOG(Message) << "Complete. Writing results to " << par().output << std::endl;
+    saveResult(par().output, "SubtractionOperators", result);
+    envGet(HadronsSerializable, getName()) = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MScalar/ChargedProp.cpp
+++ b/Hadrons/Modules/MScalar/ChargedProp.cpp
@@ -40,18 +40,18 @@ TChargedProp::TChargedProp(const std::string name)
 {}
 
 // dependencies/products ///////////////////////////////////////////////////////
-std::vector<std::string> TChargedProp::getInput()
+std::vector<std::string> TChargedProp::getInput(void)
 {
     return {par().source, par().emField};
 }
 
-std::vector<std::string> TChargedProp::getOutput()
+std::vector<std::string> TChargedProp::getOutput(void)
 {
     return {getName(), getName()+"_0", getName()+"_Q", getName()+"_Sun", getName()+"_Tad", getName()+"_projections"};
 }
 
 // setup ///////////////////////////////////////////////////////////////////////
-void TChargedProp::setup()
+void TChargedProp::setup(void)
 {
     freeMomPropName_ = FREEMOMPROP(par().mass);
     phaseName_.clear();
@@ -89,7 +89,7 @@ void TChargedProp::setup()
 }
 
 // execution ///////////////////////////////////////////////////////////////////
-void TChargedProp::execute()
+void TChargedProp::execute(void)
 {
     // CACHING ANALYTIC EXPRESSIONS
     makeCaches();

--- a/Hadrons/Modules/MScalar/ChargedProp.cpp
+++ b/Hadrons/Modules/MScalar/ChargedProp.cpp
@@ -25,6 +25,7 @@
 /*  END LEGAL */
 #include <Hadrons/Modules/MScalar/ChargedProp.hpp>
 #include <Hadrons/Modules/MScalar/Scalar.hpp>
+#include <Hadrons/Serialization.hpp>
 
 using namespace Grid;
 using namespace Hadrons;
@@ -39,23 +40,18 @@ TChargedProp::TChargedProp(const std::string name)
 {}
 
 // dependencies/products ///////////////////////////////////////////////////////
-std::vector<std::string> TChargedProp::getInput(void)
+std::vector<std::string> TChargedProp::getInput()
 {
-    std::vector<std::string> in = {par().source, par().emField};
-    
-    return in;
+    return {par().source, par().emField};
 }
 
-std::vector<std::string> TChargedProp::getOutput(void)
+std::vector<std::string> TChargedProp::getOutput()
 {
-    std::vector<std::string> out = {getName(), getName()+"_0", getName()+"_Q",
-                                    getName()+"_Sun", getName()+"_Tad"};
-    
-    return out;
+    return {getName(), getName()+"_0", getName()+"_Q", getName()+"_Sun", getName()+"_Tad", getName()+"_projections"};
 }
 
 // setup ///////////////////////////////////////////////////////////////////////
-void TChargedProp::setup(void)
+void TChargedProp::setup()
 {
     freeMomPropName_ = FREEMOMPROP(par().mass);
     phaseName_.clear();
@@ -85,6 +81,7 @@ void TChargedProp::setup(void)
     envCreateLat(ScalarField, propQName_);
     envCreateLat(ScalarField, propSunName_);
     envCreateLat(ScalarField, propTadName_);
+    envCreate(HadronsSerializable, getName()+"_projections", 1, 0);
     envTmpLat(ScalarField, "buf");
     envTmpLat(ScalarField, "result");
     envTmpLat(ScalarField, "Amu");
@@ -92,7 +89,7 @@ void TChargedProp::setup(void)
 }
 
 // execution ///////////////////////////////////////////////////////////////////
-void TChargedProp::execute(void)
+void TChargedProp::execute()
 {
     // CACHING ANALYTIC EXPRESSIONS
     makeCaches();
@@ -135,59 +132,59 @@ void TChargedProp::execute(void)
     fft.FFT_dim(buf, GFSrc, env().getNd()-1, FFT::backward);
     prop = buf + q*propQ + q*q*propSun + q*q*propTad;
 
-    // OUTPUT IF NECESSARY
-    if (!par().output.empty())
+    // output selected momenta
+    Result result;
+    TComplex            site;
+    std::vector<int>    siteCoor;
+
+    LOG(Message) << "Saving momentum-projected propagator to file '"
+                 << resultFilename(par().output) << "' and object '"
+                 << getName()+"_projections" << "'..." << std::endl;
+    result.projection.resize(par().outputMom.size());
+    result.lattice_size = env().getGrid()->FullDimensions().toVector();
+    result.mass = par().mass;
+    result.charge = q;
+    auto nd = env().getNd();
+    auto nt = env().getGrid()->FullDimensions()[nd-1];
+    siteCoor.resize(nd);
+    for (unsigned int i_p = 0; i_p < par().outputMom.size(); ++i_p)
     {
-        Result result;
-        TComplex            site;
-        std::vector<int>    siteCoor;
+        result.projection[i_p].momentum = strToVec<int>(par().outputMom[i_p]);
 
-        LOG(Message) << "Saving momentum-projected propagator to '"
-                     << resultFilename(par().output) << "'..."
-                     << std::endl;
-        result.projection.resize(par().outputMom.size());
-        result.lattice_size = env().getGrid()->FullDimensions().toVector();
-        result.mass = par().mass;
-        result.charge = q;
-        siteCoor.resize(env().getNd());
-        for (unsigned int i_p = 0; i_p < par().outputMom.size(); ++i_p)
+        LOG(Message) << "Calculating (" << par().outputMom[i_p]
+                     << ") momentum projection" << std::endl;
+
+        result.projection[i_p].corr_0.resize(nt);
+        result.projection[i_p].corr.resize(nt);
+        result.projection[i_p].corr_Q.resize(nt);
+        result.projection[i_p].corr_Sun.resize(nt);
+        result.projection[i_p].corr_Tad.resize(nt);
+
+        for (unsigned int j = 0; j < nd-1; ++j)
         {
-            result.projection[i_p].momentum = strToVec<int>(par().outputMom[i_p]);
-
-            LOG(Message) << "Calculating (" << par().outputMom[i_p]
-                         << ") momentum projection" << std::endl;
-
-            result.projection[i_p].corr_0.resize(env().getGrid()->FullDimensions()[env().getNd()-1]);
-            result.projection[i_p].corr.resize(env().getGrid()->FullDimensions()[env().getNd()-1]);
-            result.projection[i_p].corr_Q.resize(env().getGrid()->FullDimensions()[env().getNd()-1]);
-            result.projection[i_p].corr_Sun.resize(env().getGrid()->FullDimensions()[env().getNd()-1]);
-            result.projection[i_p].corr_Tad.resize(env().getGrid()->FullDimensions()[env().getNd()-1]);
-
-            for (unsigned int j = 0; j < env().getNd()-1; ++j)
-            {
-                siteCoor[j] = result.projection[i_p].momentum[j];
-            }
-
-            for (unsigned int t = 0; t < result.projection[i_p].corr.size(); ++t)
-            {
-                siteCoor[env().getNd()-1] = t;
-                peekSite(site, prop, siteCoor);
-                result.projection[i_p].corr[t]=TensorRemove(site);
-                peekSite(site, buf, siteCoor);
-                result.projection[i_p].corr_0[t]=TensorRemove(site);
-                peekSite(site, propQ, siteCoor);
-                result.projection[i_p].corr_Q[t]=TensorRemove(site);
-                peekSite(site, propSun, siteCoor);
-                result.projection[i_p].corr_Sun[t]=TensorRemove(site);
-                peekSite(site, propTad, siteCoor);
-                result.projection[i_p].corr_Tad[t]=TensorRemove(site);
-            }
+            siteCoor[j] = result.projection[i_p].momentum[j];
         }
-        saveResult(par().output, "prop", result);
-    }
 
-    std::vector<int> mask(env().getNd(),1);
-    mask[env().getNd()-1] = 0;
+        for (unsigned int t = 0; t < result.projection[i_p].corr.size(); ++t)
+        {
+            siteCoor[nd-1] = t;
+            peekSite(site, prop, siteCoor);
+            result.projection[i_p].corr[t]=TensorRemove(site);
+            peekSite(site, buf, siteCoor);
+            result.projection[i_p].corr_0[t]=TensorRemove(site);
+            peekSite(site, propQ, siteCoor);
+            result.projection[i_p].corr_Q[t]=TensorRemove(site);
+            peekSite(site, propSun, siteCoor);
+            result.projection[i_p].corr_Sun[t]=TensorRemove(site);
+            peekSite(site, propTad, siteCoor);
+            result.projection[i_p].corr_Tad[t]=TensorRemove(site);
+        }
+    }
+    saveResult(par().output, "prop", result);
+    envGet(HadronsSerializable, getName()+"_projections") = result;
+
+    std::vector<int> mask(nd,1);
+    mask[nd-1] = 0;
     fft.FFT_dim_mask(prop, prop, mask, FFT::backward);
     fft.FFT_dim_mask(propQ, propQ, mask, FFT::backward);
     fft.FFT_dim_mask(propSun, propSun, mask, FFT::backward);

--- a/Hadrons/Modules/MScalar/FreeProp.cpp
+++ b/Hadrons/Modules/MScalar/FreeProp.cpp
@@ -40,18 +40,18 @@ TFreeProp::TFreeProp(const std::string name)
 {}
 
 // dependencies/products ///////////////////////////////////////////////////////
-std::vector<std::string> TFreeProp::getInput()
+std::vector<std::string> TFreeProp::getInput(void)
 {
     return {par().source};
 }
 
-std::vector<std::string> TFreeProp::getOutput()
+std::vector<std::string> TFreeProp::getOutput(void)
 {
     return {getName(), getName()+"_sliceSum"};
 }
 
 // setup ///////////////////////////////////////////////////////////////////////
-void TFreeProp::setup()
+void TFreeProp::setup(void)
 {
     freeMomPropName_ = FREEMOMPROP(par().mass);
     
@@ -62,7 +62,7 @@ void TFreeProp::setup()
 }
 
 // execution ///////////////////////////////////////////////////////////////////
-void TFreeProp::execute()
+void TFreeProp::execute(void)
 {
     auto &freeMomProp = envGet(ScalarField, freeMomPropName_);
     auto &prop        = envGet(ScalarField, getName());

--- a/Hadrons/Modules/MScalarSUN/Div.hpp
+++ b/Hadrons/Modules/MScalarSUN/Div.hpp
@@ -94,13 +94,13 @@ TDiv<SImpl>::TDiv(const std::string name)
 
 // dependencies/products ///////////////////////////////////////////////////////
 template <typename SImpl>
-std::vector<std::string> TDiv<SImpl>::getInput()
+std::vector<std::string> TDiv<SImpl>::getInput(void)
 {
     return par().op;
 }
 
 template <typename SImpl>
-std::vector<std::string> TDiv<SImpl>::getOutput()
+std::vector<std::string> TDiv<SImpl>::getOutput(void)
 {
     return {getName(), getName()+"_sum"};
 }

--- a/Hadrons/Modules/MScalarSUN/EMT.hpp
+++ b/Hadrons/Modules/MScalarSUN/EMT.hpp
@@ -30,6 +30,7 @@
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
 #include <Hadrons/Modules/MScalarSUN/Utils.hpp>
+#include <Hadrons/Serialization.hpp>
 
 BEGIN_HADRONS_NAMESPACE
 
@@ -130,6 +131,7 @@ std::vector<std::string> TEMT<SImpl>::getOutput(void)
     {
         out.push_back(varName(getName(), mu, nu));
     }
+    out.push_back(getName());
 
     return out;
 }
@@ -143,6 +145,7 @@ void TEMT<SImpl>::setup(void)
     {
         envCreateLat(ComplexField, varName(getName(), mu, nu));
     }
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -202,10 +205,9 @@ void TEMT<SImpl>::execute(void)
             result.value[mu][nu] = result.value[nu][mu];
         }
     }
-    if (!par().output.empty())
-    {
-        saveResult(par().output, "emt", result);
-    }
+
+    saveResult(par().output, "emt", result);
+    envGet(HadronsSerializable, getName()) = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MScalarSUN/Grad.hpp
+++ b/Hadrons/Modules/MScalarSUN/Grad.hpp
@@ -30,6 +30,7 @@
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
 #include <Hadrons/Modules/MScalarSUN/Utils.hpp>
+#include <Hadrons/Serialization.hpp>
 
 BEGIN_HADRONS_NAMESPACE
 
@@ -109,6 +110,7 @@ std::vector<std::string> TGrad<SImpl>::getOutput(void)
     {
         out.push_back(varName(getName(), mu));
     }
+    out.push_back(getName());
 
     return out;
 }
@@ -123,6 +125,7 @@ void TGrad<SImpl>::setup(void)
     {
         envCreateLat(ComplexField, varName(getName(), mu));
     }
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -151,10 +154,9 @@ void TGrad<SImpl>::execute(void)
             result.value[mu] = TensorRemove(sum(der));
         }
     }
-    if (!par().output.empty())
-    {
-        saveResult(par().output, "grad", result);
-    }
+
+    saveResult(par().output, "grad", result);
+    envGet(HadronsSerializable, getName()) = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MScalarSUN/TrKinetic.hpp
+++ b/Hadrons/Modules/MScalarSUN/TrKinetic.hpp
@@ -30,6 +30,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Hadrons/Modules/MScalarSUN/Utils.hpp>
 
 BEGIN_HADRONS_NAMESPACE
@@ -111,6 +112,7 @@ std::vector<std::string> TTrKinetic<SImpl>::getOutput(void)
         out.push_back(varName(getName(), mu, nu));
     }
     out.push_back(varName(getName(), "sum"));
+    out.push_back(getName());
     
     return out;
 }
@@ -125,6 +127,7 @@ void TTrKinetic<SImpl>::setup(void)
         envCreateLat(ComplexField, varName(getName(), mu, nu));
     }
     envCreateLat(ComplexField, varName(getName(), "sum"));
+    envCreate(HadronsSerializable, getName(), 1, 0);
     envTmp(std::vector<Field>, "der", 1, env().getNd(), envGetGrid(Field));
 }
 
@@ -168,6 +171,7 @@ void TTrKinetic<SImpl>::execute(void)
         }
     }
     saveResult(par().output, "trkinetic", result);
+    envGet(HadronsSerializable, getName()) = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MScalarSUN/TrMag.hpp
+++ b/Hadrons/Modules/MScalarSUN/TrMag.hpp
@@ -29,6 +29,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Hadrons/Modules/MScalarSUN/Utils.hpp>
 
 BEGIN_HADRONS_NAMESPACE
@@ -102,15 +103,15 @@ std::vector<std::string> TTrMag<SImpl>::getInput(void)
 template <typename SImpl>
 std::vector<std::string> TTrMag<SImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
-    
-    return out;
+    return {getName()};
 }
 
 // setup ///////////////////////////////////////////////////////////////////////
 template <typename SImpl>
 void TTrMag<SImpl>::setup(void)
-{}
+{
+    envCreate(HadronsSerializable, getName(), 1, 0);
+}
 
 // execution ///////////////////////////////////////////////////////////////////
 template <typename SImpl>
@@ -137,6 +138,7 @@ void TTrMag<SImpl>::execute(void)
         result.push_back(r);
     }
     saveResult(par().output, "trmag", result);
+    envGet(HadronsSerializable, getName()) = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MScalarSUN/TrPhi.hpp
+++ b/Hadrons/Modules/MScalarSUN/TrPhi.hpp
@@ -29,6 +29,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Hadrons/Modules/MScalarSUN/Utils.hpp>
 
 BEGIN_HADRONS_NAMESPACE
@@ -109,6 +110,7 @@ std::vector<std::string> TTrPhi<SImpl>::getOutput(void)
     {
         out.push_back(varName(getName(), n));
     }
+    out.push_back(getName());
     
     return out;
 }
@@ -127,6 +129,7 @@ void TTrPhi<SImpl>::setup(void)
     {
         envCreateLat(ComplexField, varName(getName(), n));
     }
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -158,10 +161,8 @@ void TTrPhi<SImpl>::execute(void)
             result.push_back(r);
         }
     }
-    if (result.size() > 0)
-    {
-        saveResult(par().output, "trphi", result);
-    }
+    saveResult(par().output, "trphi", result);
+    envGet(HadronsSerializable, getName()) = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MScalarSUN/TransProj.hpp
+++ b/Hadrons/Modules/MScalarSUN/TransProj.hpp
@@ -30,6 +30,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Hadrons/Modules/MScalarSUN/Utils.hpp>
 
 BEGIN_HADRONS_NAMESPACE
@@ -111,6 +112,7 @@ std::vector<std::string> TTransProj<SImpl>::getOutput(void)
     {
         out.push_back(varName(getName(), mu, nu));
     }
+    out.push_back(getName());
     
     return out;
 }
@@ -127,6 +129,7 @@ void TTransProj<SImpl>::setup(void)
     envTmpLat(ComplexField, "buf1");
     envTmpLat(ComplexField, "buf2");
     envTmpLat(ComplexField, "lap");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -173,10 +176,9 @@ void TTransProj<SImpl>::execute(void)
             result.value[mu][nu] = result.value[nu][mu];
         }
     }
-    if (!par().output.empty())
-    {
-        saveResult(par().output, "transproj", result);
-    }
+
+    saveResult(par().output, "transproj", result);
+    envGet(HadronsSerializable, getName()) = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MScalarSUN/TwoPoint.hpp
+++ b/Hadrons/Modules/MScalarSUN/TwoPoint.hpp
@@ -29,6 +29,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Hadrons/Modules/MScalarSUN/Utils.hpp>
 
 BEGIN_HADRONS_NAMESPACE
@@ -119,9 +120,7 @@ std::vector<std::string> TTwoPoint<SImpl>::getInput(void)
 template <typename SImpl>
 std::vector<std::string> TTwoPoint<SImpl>::getOutput(void)
 {
-    std::vector<std::string> out = {};
-
-    return out;
+    return {getName()};
 }
 
 // setup ///////////////////////////////////////////////////////////////////////
@@ -145,6 +144,7 @@ void TTwoPoint<SImpl>::setup(void)
         }
     }
     envTmpLat(ComplexField, "ftBuf");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -215,6 +215,7 @@ void TTwoPoint<SImpl>::execute(void)
         result.push_back(r);
     }
     saveResult(par().output, "twopt", result);
+    envGet(HadronsSerializable, getName()) = result;
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MScalarSUN/TwoPointNPR.hpp
+++ b/Hadrons/Modules/MScalarSUN/TwoPointNPR.hpp
@@ -29,6 +29,7 @@
 #include <Hadrons/Global.hpp>
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
 #include <Hadrons/Modules/MScalarSUN/Utils.hpp>
 
 BEGIN_HADRONS_NAMESPACE
@@ -105,9 +106,7 @@ std::vector<std::string> TTwoPointNPR<SImpl>::getInput(void)
 template <typename SImpl>
 std::vector<std::string> TTwoPointNPR<SImpl>::getOutput(void)
 {
-    std::vector<std::string> out;
-    
-    return out;
+    return {getName()};
 }
 
 // setup ///////////////////////////////////////////////////////////////////////
@@ -125,6 +124,7 @@ void TTwoPointNPR<SImpl>::setup(void)
     }
     envTmpLat(ComplexField, "ftBuf");
     envTmpLat(Field, "ftMatBuf");
+    envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
 // execution ///////////////////////////////////////////////////////////////////
@@ -207,6 +207,7 @@ void TTwoPointNPR<SImpl>::execute(void)
         doAux = false;
     }
     saveResult(par().output, "twoptnpr", result);
+    envGet(HadronsSerializable, getName()) = result;
 }
 
 END_MODULE_NAMESPACE

--- a/tests/Test_result_bundling.cpp
+++ b/tests/Test_result_bundling.cpp
@@ -126,17 +126,17 @@ int main(int argc, char *argv[])
                                                            weakNonEyePar);
 
     // Demonstrate the bundling of two Serializables within a group
-    MIO::CorrelatorGroup::Par correlatorGroupPar;
-    correlatorGroupPar.contractions = std::vector<std::string>{"meson_pt_ss_5X", "meson_pt_ss_5YZ"};
-    application.createModule<MIO::CorrelatorGroup>("Group2pts",
-                                                    correlatorGroupPar);
+    MIO::ResultGroup::Par resultGroupPar;
+    resultGroupPar.results = std::vector<std::string>{"meson_pt_ss_5X", "meson_pt_ss_5YZ"};
+    application.createModule<MIO::ResultGroup>("Group2pts",
+                                               resultGroupPar);
 
     // Now demonstrate bundling the group with another Serializable
-    MIO::WriteCorrelatorGroup::Par writeCorrelatorGroupPar;
-    writeCorrelatorGroupPar.contractions = std::vector<std::string>{"meson_noneye_ss", "Group2pts"};
-    writeCorrelatorGroupPar.output       = "resultbundle_test/output";
-    application.createModule<MIO::WriteCorrelatorGroup>("WriteToFile",
-                                                        writeCorrelatorGroupPar);
+    MIO::WriteResultGroup::Par writeResultGroupPar;
+    writeResultGroupPar.results = std::vector<std::string>{"meson_noneye_ss", "Group2pts"};
+    writeResultGroupPar.output  = "resultbundle_test/output";
+    application.createModule<MIO::WriteResultGroup>("WriteToFile",
+                                                    writeResultGroupPar);
 
 
     // execution


### PR DESCRIPTION
Adds file bundling features to the remaining contraction modules with file outputs, as has been done with the Meson and WeakNonEye modules.
Other modules such as those in MNPR with outputs can also have the functionality extended to those, which can be pushed as additional commits if required.