### PR TITLE
Further decrease spectrum test runtime

### DIFF
--- a/tests/Test_hadrons_spectrum.cpp
+++ b/tests/Test_hadrons_spectrum.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
         // actions
         MAction::DWF::Par actionPar;
         actionPar.gauge = "gauge";
-        actionPar.Ls    = 12;
+        actionPar.Ls    = 8;
         actionPar.M5    = 1.8;
         actionPar.mass  = mass[i];
         actionPar.boundary = boundary;
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
         // solvers
         MSolver::RBPrecCG::Par solverPar;
         solverPar.action       = "DWF_" + flavour[i];
-        solverPar.residual     = 1.0e-8;
+        solverPar.residual     = 1.0e-3;  // High residual for test purposes only. Use 1.0e-8 or smaller for physics workflows.
         solverPar.maxIteration = 10000;
         application.createModule<MSolver::RBPrecCG>("CG_" + flavour[i],
                                                     solverPar);


### PR DESCRIPTION
With the recent changes, the coverage build time is down to a bit more than 2 hours which still feels quite long.
I therefore propose to increase the solver residual to 1e-3 and decrease Ls to 8 to speed up the test further. I expect a reduction in coverage build time by another ~60%.

I added a comment in the test which clarifies that one should not use such high residuals in physics workflows.