### PR TITLE
Rewrote FourQuarkFullyConnected module with lower memory footprint

### DIFF
--- a/Hadrons/Modules/MNPR/FourQuarkFullyConnected.hpp
+++ b/Hadrons/Modules/MNPR/FourQuarkFullyConnected.hpp
@@ -125,7 +125,7 @@ void TFourQuarkFullyConnected<FImpl>::setup()
 
     envTmpLat(PropagatorField, "bilinear");
     envTmpLat(PropagatorField, "bilinear_tmp");
-    envTmpLat(SpinColourSpinColourMatrixField, "lret");
+    envTmpLat(PropagatorField, "bilinear_sum");
     envTmpLat(ComplexField, "bilinear_phase");
 
     envCreate(HadronsSerializable, getName(), 1, 0);
@@ -143,7 +143,7 @@ void TFourQuarkFullyConnected<FImpl>::execute()
 
     envGetTmp(PropagatorField, bilinear);
     envGetTmp(PropagatorField, bilinear_tmp);
-    envGetTmp(SpinColourSpinColourMatrixField, lret);
+    envGetTmp(PropagatorField, bilinear_sum);
 
 
     std::vector<Result>         result;
@@ -184,14 +184,15 @@ void TFourQuarkFullyConnected<FImpl>::execute()
         // Fully connected diagram
         bilinear = bilinear_phase * (g5 * adj(qOut) * g5 * gamma_A * qIn);
 
+        SpinColourSpinColourMatrix lret;
         if (gamma_A.g == gamma_B.g) {
-            NPRUtils<FImpl>::tensorProd(lret, bilinear, bilinear);
+            lret = NPRUtils<FImpl>::tensorProdSum(bilinear_sum, bilinear, bilinear);
         }
         else {
             bilinear_tmp = bilinear_phase * (g5 * adj(qOut) * g5 * gamma_B * qIn);
-            NPRUtils<FImpl>::tensorProd(lret, bilinear, bilinear_tmp);
+            lret = NPRUtils<FImpl>::tensorProdSum(bilinear_sum, bilinear, bilinear_tmp);
         }
-        r.corr.push_back( (1.0 / volume) * sum_large(lret) );
+        r.corr.push_back( (1.0 / volume) * lret );
         result.push_back(r);
         r.corr.erase(r.corr.begin());
     };

--- a/Hadrons/Modules/MNPR/NPRUtils.hpp
+++ b/Hadrons/Modules/MNPR/NPRUtils.hpp
@@ -68,11 +68,7 @@ SpinColourSpinColourMatrix NPRUtils<FImpl>::tensorProdSum(PropagatorField &tsum,
 	        {
                 for (int cj=0; cj < Nc; ++cj)
 	            {
-                    thread_for( site, tsum_v.size(), {
-                        vTComplex left;
-                        left()()() = a_v[site]()(si,sj)(ci,cj);
-                        tsum_v[site]()=left()*b_v[site]();
-                    });
+                    tsum = peekColour(peekSpin(a, si, sj), ci, cj) * b;
                     result()(si,sj)(ci,cj) = sum(tsum)();
                 }
             }

--- a/Hadrons/Modules/MNPR/NPRUtils.hpp
+++ b/Hadrons/Modules/MNPR/NPRUtils.hpp
@@ -56,9 +56,6 @@ template <typename FImpl>
 SpinColourSpinColourMatrix NPRUtils<FImpl>::tensorProdSum(PropagatorField &tsum, PropagatorField &a, PropagatorField &b)
 {
     SpinColourSpinColourMatrix result;
-    autoView(tsum_v, tsum, CpuWrite);
-    autoView(a_v, a, CpuRead);
-    autoView(b_v, b, CpuRead);
 
     for(int si=0; si < Ns; ++si)
 	{

--- a/Hadrons/Modules/MNPR/NPRUtils.hpp
+++ b/Hadrons/Modules/MNPR/NPRUtils.hpp
@@ -66,7 +66,7 @@ SpinColourSpinColourMatrix NPRUtils<FImpl>::tensorProdSum(PropagatorField &tsum,
                 for (int cj=0; cj < Nc; ++cj)
 	            {
                     tsum = peekColour(peekSpin(a, si, sj), ci, cj) * b;
-                    result()(si,sj)(ci,cj) = sum(tsum)();
+                    result()(si,sj)(ci,cj) = sum_large(tsum)();
                 }
             }
         }


### PR DESCRIPTION
I rewrote the `FourQuarkFullyConnected` module and the accompanying `NPRUtils` to use smaller temporary objects, effectively reducing the module's memory requirements by a factor of ~50. On my laptop I additionally see a small speedup. By exchanging the loop order I compute the sum over each of the 144 `Propagatorfields` sequentially instead of assembling a large `SpinColourSpinColourMatrixField` and then doing the sum. On my laptop I achieve bit identical results for various momenta on a random gauge field.

These changes should allow us to run the `FourQuarkFullyConnected` module on GPUs without having to worry about the required memory.