### PR TITLE
Fix sql schema string

### DIFF
--- a/Hadrons/SqlEntry.hpp
+++ b/Hadrons/SqlEntry.hpp
@@ -331,7 +331,7 @@ SqlEntry::sqlType(void)
  ******************************************************************************/
 #define HADRONS_SQL_MEMBER(A, B)      HADRONS_NAMESPACE::CppType<A>::type B;
 #define HADRONS_SQL_BOOL_MEMBER(A, B) bool B{false};
-#define HADRONS_SQL_SCHEMA(A, B)      schema += std::string(#B) + " " + sqlType<A>() + ",";
+#define HADRONS_SQL_SCHEMA(A, B)      schema += "'" + std::string(#B) + "' " + sqlType<A>() + ",";
 #define HADRONS_SQL_INSERT(A, B)\
 if (nullify.B)\
 {\


### PR DESCRIPTION
Here is a fix for the macro creating the sql schema string. This fix puts the column name in single quotes so it is not interpreted as sql.
For example, I ran into this by trying to have a column named `order` that threw an sql error when trying to create the table.