### PR TITLE
Fix compile issue

### DIFF
--- a/Hadrons/Global.hpp
+++ b/Hadrons/Global.hpp
@@ -78,17 +78,17 @@ using Grid::operator>>;
 #define HADRONS_IMPL(impl, sub)   _HADRONS_IMPL(impl, sub)
 
 typedef Grid::WilsonImpl<Grid::vComplex, 
-                         Grid::FundamentalRep<1>, 
+                         Grid::FundamentalRep<1,Grid::GroupName::SU>, 
                          Grid::CoeffReal> LeptonWilsonImplR;
 typedef Grid::WilsonImpl<Grid::vComplexF, 
-                         Grid::FundamentalRep<1>, 
+                         Grid::FundamentalRep<1,Grid::GroupName::SU>, 
                          Grid::CoeffReal> LeptonWilsonImplF;
 typedef Grid::WilsonImpl<Grid::vComplexD, 
-                         Grid::FundamentalRep<1>, 
+                         Grid::FundamentalRep<1,Grid::GroupName::SU>, 
                          Grid::CoeffReal> LeptonWilsonImplD;
-typedef Grid::PeriodicGaugeImpl<Grid::GaugeImplTypes<Grid::vComplex, 1>> PeriodicGImplU1;
-typedef Grid::PeriodicGaugeImpl<Grid::GaugeImplTypes<Grid::vComplexF, 1>> PeriodicGImplU1F;
-typedef Grid::PeriodicGaugeImpl<Grid::GaugeImplTypes<Grid::vComplexD, 1>> PeriodicGImplU1D;
+typedef Grid::PeriodicGaugeImpl<Grid::GaugeImplTypes<Grid::vComplex, 1, 12, Grid::SU<1>>> PeriodicGImplU1;
+typedef Grid::PeriodicGaugeImpl<Grid::GaugeImplTypes<Grid::vComplexF, 1, 12, Grid::SU<1>>> PeriodicGImplU1F;
+typedef Grid::PeriodicGaugeImpl<Grid::GaugeImplTypes<Grid::vComplexD, 1, 12, Grid::SU<1>>> PeriodicGImplU1D;
 
 #ifndef FIMPLBASE
 #define FIMPLBASE WilsonImpl


### PR DESCRIPTION
Here is a fix for the compilation of Hadrons using the latest version of Grid.
The problem is related to the changes made in the big SP(2N) update.

I had to set the `PeriodicGImplU1` group types to `SU<1>` but I'm not too sure about that since they are actually meant to be U1 fields (there is no `Grid::U<N>` group as far as I know), but I think this is the updated version of what it was doing before. 
It would be good for someone to check this doesn't break anything