### PR TITLE
fix application template configure script

### DIFF
--- a/application-template/configure.ac
+++ b/application-template/configure.ac
@@ -35,11 +35,6 @@ if test x"$CXXLD" == x ; then
 elif test "$CXXLD" != "`hadrons-config --cxxld`" ; then
     AC_MSG_WARN([CXXLD differs from that reported by hadrons-config])
 fi
-CXXFLAGS="$CXXFLAGS `hadrons-config --cxxflags`"
-LDFLAGS="$LDFLAGS `hadrons-config --ldflags`"
-CXXFLAGS="$AM_CXXFLAGS $CXXFLAGS"
-LDFLAGS="$AM_LDFLAGS $LDFLAGS"
-LIBS=" -lHadrons $LIBS `hadrons-config --libs`"
 
 # Checks for programs.
 AC_PROG_CXX
@@ -47,6 +42,12 @@ AC_PROG_CC
 AC_PROG_RANLIB
 AM_PROG_AR
 AC_LANG([C++])
+
+CXXFLAGS="$CXXFLAGS `hadrons-config --cxxflags`"
+LDFLAGS="$LDFLAGS `hadrons-config --ldflags`"
+CXXFLAGS="$AM_CXXFLAGS $CXXFLAGS"
+LDFLAGS="$AM_LDFLAGS $LDFLAGS"
+LIBS=" -lHadrons $LIBS `hadrons-config --libs`"
 
 AC_MSG_CHECKING([that a minimal Grid/Hadrons program compiles]);
 AC_LINK_IFELSE(


### PR DESCRIPTION
Few month ago (while working on automatic app deployment), I fixed the configure script in many Hadrons applications. Apparently some of the necessary changes did not make their way back into the application-template. This PR rectifies this, bringing the template and our production applications back in line.

The issue itself is just a matter of order of operations. In practice it manifests itself as a error during `configure` that reads something like `configure: error: C++ compiler cannot create executables`. A strange workaround in the past was to add something nonsensical like "--host=aarch64" to pretend to be cross-compiling.