### PR TITLE
Stat db gpu improvments

### DIFF
--- a/Hadrons/StatLogger.hpp
+++ b/Hadrons/StatLogger.hpp
@@ -59,6 +59,7 @@ public:
                            SqlNotNull<size_t>, envCurrent,
                            SqlNotNull<size_t>, gridCurrent,
                            SqlNotNull<size_t>, gridCacheCurrent,
+			   SqlNotNull<size_t>, gridCommsCurrent,
                            SqlNotNull<size_t>, gridTotalCurrent,
                            SqlNotNull<size_t>, evictableCurrent,
                            SqlNotNull<size_t>, hostToDevice,


### PR DESCRIPTION
I've added the gpu comms memory and the total memory usage reported by cuda to the stat db.
Now `e.gridTotalCurrent` is the total memory allocated on thee gpu by grid (in use objects + cache + comms).

I have also added a new column in the view `gridDeficitCurrentMB` which is the total memory reported by cuda minus grids total usage.
I've been using this to try to debug cases where the deficit jumps suddenly. 
It is also useful to see how much headroom we have to increase the `--device-mem` flag. 