### PR TITLE
Feature/Gradient Flow

### DIFF
--- a/Hadrons/Modules/MGradientFlow/FermionFlow.cpp
+++ b/Hadrons/Modules/MGradientFlow/FermionFlow.cpp
@@ -1,0 +1,33 @@
+/*
+ * FermionFlow.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2022
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Matthew Black    <matthewkblack@protonmail.com>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+#include <Hadrons/Modules/MGradientFlow/FermionFlow.hpp>
+
+using namespace Grid;
+using namespace Hadrons;
+using namespace MGradientFlow;
+
+template class Grid::Hadrons::MGradientFlow::TFermionFlow<FIMPL,GIMPL,WilsonGaugeAction<GIMPL>>;

--- a/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
@@ -201,7 +201,6 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
     }
     
     // apply flow equations
-    double time = 0;
     Evolution<FlowAction> evolve(3.0, par().step_size, -1.0, par().step_size);
     for (unsigned int step = 1; step <= par().steps; step++) {
         // evolve gauge field 

--- a/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
@@ -1,0 +1,256 @@
+/*
+ * FermionFlow.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2022
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Matthew Black    <matthewkblack@protonmail.com>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+#ifndef Hadrons_MGradientFlow_FermionFlow_hpp_
+#define Hadrons_MGradientFlow_FermionFlow_hpp_
+
+#include <Hadrons/Global.hpp>
+#include <Hadrons/Module.hpp>
+#include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
+#include <Hadrons/TimerArray.hpp>
+#include <Hadrons/Modules/MGradientFlow/Utils.hpp>
+
+BEGIN_HADRONS_NAMESPACE
+
+/******************************************************************************
+ *                      Propagator Field Gradient Flow                        *
+ ******************************************************************************/
+BEGIN_MODULE_NAMESPACE(MGradientFlow)
+
+class FermionFlowPar: Serializable
+{
+public:
+    GRID_SERIALIZABLE_CLASS_MEMBERS(FermionFlowPar,
+                                    std::string, output,
+                                    std::vector<std::string>, props,
+                                    std::string, gauge,
+                                    int, bc,
+                                    int, steps,
+                                    double, step_size,
+                                    int, meas_interval,
+                                    std::string, maxTau);
+};
+
+template <typename FImpl,typename GImpl,typename FlowAction>
+class TFermionFlow: public Module<FermionFlowPar>
+{
+public:
+    /*FERM_TYPE_ALIASES(FImpl,);
+    INHERIT_GIMPL_TYPES(GImpl);*/
+    BASIC_TYPE_ALIASES(FImpl,);
+    GAUGE_TYPE_ALIASES(GImpl,);
+    class GaugeResult : Serializable
+    {
+    public:
+        GRID_SERIALIZABLE_CLASS_MEMBERS(GaugeResult,
+                                        std::vector<double>,    plaquette,
+                                        std::vector<double>,    rectangle,
+                                        std::vector<double>,    clover,
+                                        std::vector<double>,    topcharge,
+                                        std::vector<double>,    action,
+                                        std::vector<ComplexD>,  polyakov);
+    };
+public:
+    // constructor
+    TFermionFlow(const std::string name);
+    // destructor
+    virtual ~TFermionFlow(void) {};
+    // dependency relation
+    virtual std::vector<std::string> getInput(void);
+    virtual std::vector<std::string> getOutput(void);
+    // setup
+    virtual void setup(void);
+    // action
+    FlowAction SG = FlowAction(3.0);
+    // execution
+    virtual void execute(void);
+};
+
+MODULE_REGISTER_TMP(WilsonFermionFlow,ARG(TFermionFlow<FIMPL,GIMPL,WilsonGaugeAction<GIMPL>>),MGradientFlow);
+
+/******************************************************************************
+ *                     TFermionFlow implementation                          *
+ ******************************************************************************/
+// constructor /////////////////////////////////////////////////////////////////
+template <typename FImpl,typename GImpl,typename FlowAction>
+TFermionFlow<FImpl,GImpl,FlowAction>::TFermionFlow(const std::string name)
+: Module<FermionFlowPar>(name)
+{}
+
+// dependencies/products ///////////////////////////////////////////////////////
+template <typename FImpl,typename GImpl,typename FlowAction>
+std::vector<std::string> TFermionFlow<FImpl,GImpl,FlowAction>::getInput(void)
+{
+    std::vector<std::string> in = {par().gauge}; 
+    for (std::string q : par().props) {
+        in.push_back(q);
+    }
+    
+    return in;
+}
+
+template <typename FImpl,typename GImpl,typename FlowAction>
+std::vector<std::string> TFermionFlow<FImpl,GImpl,FlowAction>::getOutput(void)
+{
+    std::vector<std::string> out = {getName(),getName()+"_U"};
+    for (int i = 1; i <= par().steps; i++) 
+    {
+        if ((i % par().meas_interval == 0) || (i == par().steps)) {
+            std::stringstream st; st << i;
+            for (int j = 0; j < par().props.size(); j++) {
+                std::stringstream qt; qt << j;
+                out.push_back(getName()+"_q"+qt.str()+"_"+st.str());
+            }
+        }
+    }
+    return out;
+}
+
+// setup ///////////////////////////////////////////////////////////////////////
+template <typename FImpl,typename GImpl,typename FlowAction>
+void TFermionFlow<FImpl,GImpl,FlowAction>::setup(void)
+{
+    envCreateLat(GaugeField, getName()+"_U");
+
+    for (int j = 0; j < par().props.size(); j++) {
+        std::stringstream qt; qt << j;
+        envTmpLat(PropagatorField, "q"+qt.str()+"wf");
+    }
+
+    for (int i = 1; i <= par().steps; i++) 
+    {
+        if ((i % par().meas_interval == 0) || (i == par().steps)) {
+            std::stringstream st; st << i;
+            for (int j = 0; j < par().props.size(); j++) {
+                std::stringstream qt; qt << j;
+                envCreateLat(PropagatorField, getName()+"_q"+qt.str()+"_"+st.str());
+            }
+        }
+    }
+    envCreate(HadronsSerializable, getName(), 1, 0);
+}
+
+// execution ///////////////////////////////////////////////////////////////////
+template <typename FImpl,typename GImpl,typename FlowAction>
+void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
+{
+    std::string type = SG.action_name();
+    std::string ga = "GaugeAction";
+    std::string::size_type i = type.find(ga);
+    if (i != std::string::npos) {
+        type.erase(i, ga.length());
+    }
+
+    std::string props = "";
+    for (std::string q : par().props) props += q + " ";
+    LOG(Message) << "Setting up " << type << " Fermion Flow on '" << par().gauge << "' Gauge Field and "  
+                 << props << ((par().props.size() > 1) ? "Fermion Propagators " : "Fermion Propagator ")
+                 << "with ppp" << ((par().bc < 0) ? "a" : "p") << " boundary conditions and "
+                 << par().steps << " step" << ((par().steps > 1) ? "s." : ".") << std::endl;
+
+    std::vector<int> bc = {1,1,1};
+    if (par().bc < 0) bc.push_back(-1);
+    else bc.push_back(1);
+
+    double mTau = -1.0;
+    if(!par().maxTau.empty()) {
+        LOG(Message) << "Using adaptive algorithm with maxTau = " << par().maxTau << std::endl;
+        mTau = (double)std::stoi(par().maxTau);
+    }
+
+    auto &out     = envGet(HadronsSerializable, getName());
+    auto &Uresult = out.template hold<GaugeResult>();
+
+    Uresult.plaquette.resize(par().steps);
+    Uresult.rectangle.resize(par().steps);
+    Uresult.clover.resize(par().steps);
+    Uresult.topcharge.resize(par().steps);
+    Uresult.action.resize(par().steps);
+    Uresult.polyakov.resize(par().steps);
+
+    auto &U   = envGet(GaugeField, par().gauge);
+    auto &Uwf = envGet(GaugeField, getName()+"_U");
+    Uwf = U;
+
+    for (int j = 0; j < par().props.size(); j++) {
+        auto &qj = envGet(PropagatorField, par().props[j]);
+        std::stringstream jt; jt << j;
+        PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_q"+jt.str()+"wf");
+        qjwf = qj;
+    }
+    
+    double time = 0;
+    Evolution<FlowAction> evolve(3.0, par().step_size, mTau, par().step_size);
+    if (mTau > 0) {
+        unsigned int step = 0;
+        do {
+            step++;
+            startTimer("gauge field step");
+            std::vector<GaugeField> Wi = evolve.template evolve_gaugeFF_adaptive<GImpl,GaugeField,GaugeLinkField>(Uwf,bc);
+            stopTimer("gauge field step");
+            evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,GaugeResult>(Uwf,Uresult,step-1);
+            if (step % par().meas_interval == 0) {
+                std::stringstream st; st << step;
+                for (int j = 0; j < par().props.size(); j++) {
+                    std::stringstream jt; jt << j;
+                    PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_q"+jt.str()+"wf");
+                    startTimer("fermion field "+jt.str()+" step");
+                    evolve.template laplace_flow<PropagatorField,GImpl,GaugeField,GaugeLinkField>(Wi[0],Wi[1],Wi[2],qjwf);
+                    stopTimer("fermion field "+jt.str()+" step");
+                    auto &qji = envGet(PropagatorField, getName()+"_q"+jt.str()+"_"+st.str());
+                    qji = qjwf;
+                }
+            }
+        } while (evolve.taus < mTau);
+    } else {
+        for (unsigned int step = 1; step <= par().steps; step++) {
+            startTimer("gauge field step");
+            std::vector<GaugeField> Wi = evolve.template evolve_gaugeFF<GImpl,GaugeField,GaugeLinkField>(Uwf,bc);
+            stopTimer("gauge field step");
+            evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,GaugeResult>(Uwf,Uresult,step-1);
+            if ((step % par().meas_interval == 0) || (step == par().steps)) {
+                std::stringstream st; st << step;
+                for (int j = 0; j < par().props.size(); j++) {
+                    std::stringstream jt; jt << j;
+                    PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_q"+jt.str()+"wf");
+                    startTimer("fermion field "+jt.str()+" step");
+                    evolve.template laplace_flow<PropagatorField,GImpl,GaugeField,GaugeLinkField>(Wi[0],Wi[1],Wi[2],qjwf);
+                    stopTimer("fermion field "+jt.str()+" step");
+                    auto &qji = envGet(PropagatorField, getName()+"_q"+jt.str()+"_"+st.str());
+                    qji = qjwf;
+                }
+            }
+        }
+    }
+    saveResult(par().output,"gauge_obs",Uresult);
+}
+
+END_MODULE_NAMESPACE
+
+END_HADRONS_NAMESPACE
+
+#endif // Hadrons_MGradientFlow_FermionFlow_hpp_

--- a/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
@@ -81,8 +81,6 @@ public:
     virtual std::vector<std::string> getOutput(void);
     // setup
     virtual void setup(void);
-    // action
-    FlowAction SG = FlowAction(3.0);
     // execution
     virtual void execute(void);
 };
@@ -159,6 +157,9 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::setup(void)
 template <typename FImpl,typename GImpl,typename FlowAction>
 void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
 {
+    // action
+    FlowAction SG = FlowAction(3.0);
+
     std::string type = SG.action_name();
     std::string ga = "GaugeAction";
     std::string::size_type i = type.find(ga);

--- a/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
@@ -47,6 +47,7 @@ public:
     GRID_SERIALIZABLE_CLASS_MEMBERS(FermionFlowPar,
                                     std::string, output,
                                     std::vector<std::string>, props,
+                                    std::vector<std::string>, outPropStems,
                                     std::string, gauge,
                                     int, bc,
                                     int, steps,
@@ -123,8 +124,14 @@ std::vector<std::string> TFermionFlow<FImpl,GImpl,FlowAction>::getOutput(void)
         if ((i % par().meas_interval == 0) || (i == par().steps)) {
             double ft = par().step_size * i;
             std::stringstream ftt; ftt << std::fixed << std::setprecision(2) << ft;
-            for (std::string q : par().props) {
-                out.push_back(q+"_t"+ftt.str());
+            if (par().outPropStems.empty()) {
+                for (std::string q : par().props) {
+                    out.push_back(q+"_t"+ftt.str());
+                }
+            } else {
+                for (std::string q : par().outPropStems) {
+                    out.push_back(q+"_t"+ftt.str());
+                }
             }
         }
     }
@@ -149,8 +156,14 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::setup(void)
         if (( i % par().meas_interval == 0) || (i == par().steps)) {
             double ft = par().step_size * i;
             std::stringstream ftt; ftt << std::fixed << std::setprecision(2) << ft;
-            for (std::string q : par().props) {
-                envCreateLat(PropagatorField, q+"_t"+ftt.str());
+            if (par().outPropStems.empty()) {
+                for (std::string q : par().props) {
+                    envCreateLat(PropagatorField, q+"_t"+ftt.str());
+                }
+            } else {
+                for (std::string q : par().outPropStems) {
+                    envCreateLat(PropagatorField, q+"_t"+ftt.str());
+                }
             }
         }
     }
@@ -177,6 +190,10 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
                  << props << ((par().props.size() > 1) ? "Fermion Propagators " : "Fermion Propagator ")
                  << "with ppp" << ((par().bc < 0) ? "a" : "p") << " boundary conditions and "
                  << par().steps << " step" << ((par().steps > 1) ? "s." : ".") << std::endl;
+
+    if ((par().outPropStems.size() != par().props.size()) && !par().outPropStems.empty()) {
+        HADRONS_ERROR(Argument, "outPropStems should either be empty or be the same size as props");
+    }
 
     // set boundary conditions for gauge field
     std::vector<int> bc = {1,1,1};
@@ -213,13 +230,20 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
         evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,GaugeResult>(Uwf,Uresult,flowt);
 
         // evolve propagators
-        for (std::string q : par().props) {
+        for (int i = 0; i < par().props.size(); i++) {
+            std::string q = par().props[i];
             PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_"+q+"_wf");
             startTimer("propagator "+q+" flow time "+ftt.str());
             evolve.template laplace_flow<PropagatorField,GImpl,GaugeField,GaugeLinkField>(Wi[0],Wi[1],Wi[2],qjwf);
             stopTimer("propagator "+q+" flow time "+ftt.str());
             if (( step % par().meas_interval == 0) || (step == par().steps)) {
-                auto &qji = envGet(PropagatorField, q+"_t"+ftt.str());
+                std::string qo;
+                if (par().outPropStems.empty()) {
+                    qo = q;
+                } else {
+                    qo = par().outPropStems[i];
+                }
+                auto &qji = envGet(PropagatorField, qo+"_t"+ftt.str());
                 qji = qjwf;
             }
         }

--- a/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
@@ -47,7 +47,7 @@ public:
     GRID_SERIALIZABLE_CLASS_MEMBERS(FermionFlowPar,
                                     std::string, output,
                                     std::vector<std::string>, props,
-                                    std::vector<std::string>, outPropStems,
+                                    std::vector<std::string>, outProps,
                                     std::string, gauge,
                                     int, bc,
                                     int, steps,
@@ -124,13 +124,13 @@ std::vector<std::string> TFermionFlow<FImpl,GImpl,FlowAction>::getOutput(void)
         if ((i % par().meas_interval == 0) || (i == par().steps)) {
             double ft = par().step_size * i;
             std::stringstream ftt; ftt << std::fixed << std::setprecision(2) << ft;
-            if (par().outPropStems.empty()) {
+            if (par().outProps.empty()) {
                 for (std::string q : par().props) {
                     out.push_back(q+"_t"+ftt.str());
                 }
             } else {
-                for (std::string q : par().outPropStems) {
-                    out.push_back(q+"_t"+ftt.str());
+                for (std::string q : par().outProps) {
+                    out.push_back(q);
                 }
             }
         }
@@ -156,13 +156,13 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::setup(void)
         if (( i % par().meas_interval == 0) || (i == par().steps)) {
             double ft = par().step_size * i;
             std::stringstream ftt; ftt << std::fixed << std::setprecision(2) << ft;
-            if (par().outPropStems.empty()) {
+            if (par().outProps.empty()) {
                 for (std::string q : par().props) {
                     envCreateLat(PropagatorField, q+"_t"+ftt.str());
                 }
             } else {
-                for (std::string q : par().outPropStems) {
-                    envCreateLat(PropagatorField, q+"_t"+ftt.str());
+                for (std::string q : par().outProps) {
+                    envCreateLat(PropagatorField, q);
                 }
             }
         }
@@ -191,8 +191,8 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
                  << "with ppp" << ((par().bc < 0) ? "a" : "p") << " boundary conditions and "
                  << par().steps << " step" << ((par().steps > 1) ? "s." : ".") << std::endl;
 
-    if ((par().outPropStems.size() != par().props.size()) && !par().outPropStems.empty()) {
-        HADRONS_ERROR(Argument, "outPropStems should either be empty or be the same size as props");
+    if ((par().outProps.size() != par().props.size()) && !par().outProps.empty()) {
+        HADRONS_ERROR(Argument, "outProps should either be empty or be the same size as props");
     }
 
     // set boundary conditions for gauge field
@@ -238,12 +238,12 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
             stopTimer("propagator "+q+" flow time "+ftt.str());
             if (( step % par().meas_interval == 0) || (step == par().steps)) {
                 std::string qo;
-                if (par().outPropStems.empty()) {
-                    qo = q;
+                if (par().outProps.empty()) {
+                    qo = q+"_t"+ftt.str();
                 } else {
-                    qo = par().outPropStems[i];
+                    qo = par().outProps[i];
                 }
-                auto &qji = envGet(PropagatorField, qo+"_t"+ftt.str());
+                auto &qji = envGet(PropagatorField, qo);
                 qji = qjwf;
             }
         }

--- a/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
@@ -147,7 +147,7 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::setup(void)
         if ((i % par().meas_interval == 0) || (i == par().steps)) {
             double ft = par().step_size * i;
             std::stringstream ftt; ftt << ft;
-            for (std::string q : par().props()) {
+            for (std::string q : par().props) {
                 envCreateLat(PropagatorField, q+"_t"+ftt.str());
             }
         }

--- a/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
@@ -120,10 +120,10 @@ std::vector<std::string> TFermionFlow<FImpl,GImpl,FlowAction>::getOutput(void)
     for (int i = 1; i <= par().steps; i++) 
     {
         if ((i % par().meas_interval == 0) || (i == par().steps)) {
-            std::stringstream st; st << i;
-            for (int j = 0; j < par().props.size(); j++) {
-                std::stringstream qt; qt << j;
-                out.push_back(getName()+"_q"+qt.str()+"_"+st.str());
+            double ft = par().step_size * i;
+            std::stringstream ftt; ftt << ft;
+            for (std::string q : par().props) {
+                out.push_back(q+"_t"+ftt.str());
             }
         }
     }
@@ -137,19 +137,18 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::setup(void)
     envCreateLat(GaugeField, getName()+"_U");
 
     // create tmp propagator fields
-    for (int j = 0; j < par().props.size(); j++) {
-        std::stringstream qt; qt << j;
-        envTmpLat(PropagatorField, "q"+qt.str()+"wf");
+    for (std::string q : par().props) {
+        envTmpLat(PropagatorField, q+"_wf");
     }
 
     // create output propagators
     for (int i = 1; i <= par().steps; i++) 
     {
         if ((i % par().meas_interval == 0) || (i == par().steps)) {
-            std::stringstream st; st << i;
-            for (int j = 0; j < par().props.size(); j++) {
-                std::stringstream qt; qt << j;
-                envCreateLat(PropagatorField, getName()+"_q"+qt.str()+"_"+st.str());
+            double ft = par().step_size * i;
+            std::stringstream ftt; ftt << ft;
+            for (std::string q : par().props()) {
+                envCreateLat(PropagatorField, q+"_t"+ftt.str());
             }
         }
     }
@@ -199,10 +198,9 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
     auto &Uwf = envGet(GaugeField, getName()+"_U");
     Uwf = U;
 
-    for (int j = 0; j < par().props.size(); j++) {
-        auto &qj = envGet(PropagatorField, par().props[j]);
-        std::stringstream jt; jt << j;
-        PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_q"+jt.str()+"wf");
+    for (std::string q : par().props) {
+        auto &qj = envGet(PropagatorField, q);
+        PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_"+q+"_wf");
         qjwf = qj;
     }
     
@@ -219,14 +217,14 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
 
         // evolve propagators
         if ((step % par().meas_interval == 0) || (step == par().steps)) {
-            std::stringstream st; st << step;
-            for (int j = 0; j < par().props.size(); j++) {
-                std::stringstream jt; jt << j;
-                PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_q"+jt.str()+"wf");
-                startTimer("fermion field "+jt.str()+" flow");
+            double ft = par().step_size * i;
+            std::stringstream ftt; ftt << ft;
+            for (std::string q : par().props) {
+                PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_"+q+"_wf");
+                startTimer("propagator "+q+" flow");
                 evolve.template laplace_flow<PropagatorField,GImpl,GaugeField,GaugeLinkField>(Wi[0],Wi[1],Wi[2],qjwf);
-                stopTimer("fermion field "+jt.str()+" flow");
-                auto &qji = envGet(PropagatorField, getName()+"_q"+jt.str()+"_"+st.str());
+                stopTimer("propagator "+q+" flow");
+                auto &qji = envGet(PropagatorField, getName()+q+"_t"+ftt.str());
                 qji = qjwf;
             }
         }

--- a/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
@@ -64,10 +64,11 @@ public:
     {
     public:
         GRID_SERIALIZABLE_CLASS_MEMBERS(GaugeResult,
+                                        std::vector<double>,    flowtime,
                                         std::vector<double>,    plaquette,
                                         std::vector<double>,    rectangle,
                                         std::vector<double>,    clover,
-                                        std::vector<double>,    topcharge,
+                                        std::vector<double>,    topocharge,
                                         std::vector<double>,    action,
                                         std::vector<ComplexD>,  polyakovX,
                                         std::vector<ComplexD>,  polyakovY,
@@ -185,16 +186,6 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
     auto &out     = envGet(HadronsSerializable, getName());
     auto &Uresult = out.template hold<GaugeResult>();
 
-    Uresult.plaquette.resize(par().steps);
-    Uresult.rectangle.resize(par().steps);
-    Uresult.clover.resize(par().steps);
-    Uresult.topcharge.resize(par().steps);
-    Uresult.action.resize(par().steps);
-    Uresult.polyakovX.resize(par().steps);
-    Uresult.polyakovY.resize(par().steps);
-    Uresult.polyakovZ.resize(par().steps);
-    Uresult.polyakovT.resize(par().steps);
-
     auto &U   = envGet(GaugeField, par().gauge);
     auto &Uwf = envGet(GaugeField, getName()+"_U");
     Uwf = U;
@@ -206,10 +197,12 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
     }
     
     // apply flow equations
+    double flowt = 0.0;
     Evolution<FlowAction> evolve(3.0, par().step_size, -1.0, par().step_size);
+    evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,GaugeResult>(Uwf,Uresult,flowt);
     for (unsigned int step = 1; step <= par().steps; step++) {
-        double ft = par().step_size * step;
-        std::stringstream ftt; ftt << std::fixed << std::setprecision(2) << ft;
+        flowt += evolve.epsilon;
+        std::stringstream ftt; ftt << std::fixed << std::setprecision(2) << flowt;
 
         // evolve gauge field 
         startTimer("gauge field flow time "+ftt.str());
@@ -217,7 +210,7 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
         stopTimer("gauge field flow time "+ftt.str());
 
         // measure gauge observables
-        evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,GaugeResult>(Uwf,Uresult,step-1);
+        evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,GaugeResult>(Uwf,Uresult,flowt);
 
         // evolve propagators
         for (std::string q : par().props) {

--- a/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
@@ -51,16 +51,13 @@ public:
                                     int, bc,
                                     int, steps,
                                     double, step_size,
-                                    int, meas_interval,
-                                    std::string, maxTau);
+                                    int, meas_interval);
 };
 
 template <typename FImpl,typename GImpl,typename FlowAction>
 class TFermionFlow: public Module<FermionFlowPar>
 {
 public:
-    /*FERM_TYPE_ALIASES(FImpl,);
-    INHERIT_GIMPL_TYPES(GImpl);*/
     BASIC_TYPE_ALIASES(FImpl,);
     GAUGE_TYPE_ALIASES(GImpl,);
     class GaugeResult : Serializable
@@ -117,6 +114,8 @@ template <typename FImpl,typename GImpl,typename FlowAction>
 std::vector<std::string> TFermionFlow<FImpl,GImpl,FlowAction>::getOutput(void)
 {
     std::vector<std::string> out = {getName(),getName()+"_U"};
+
+    // output flowed propagator fields at measurement intervals
     for (int i = 1; i <= par().steps; i++) 
     {
         if ((i % par().meas_interval == 0) || (i == par().steps)) {
@@ -136,11 +135,13 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::setup(void)
 {
     envCreateLat(GaugeField, getName()+"_U");
 
+    // create tmp propagator fields
     for (int j = 0; j < par().props.size(); j++) {
         std::stringstream qt; qt << j;
         envTmpLat(PropagatorField, "q"+qt.str()+"wf");
     }
 
+    // create output propagators
     for (int i = 1; i <= par().steps; i++) 
     {
         if ((i % par().meas_interval == 0) || (i == par().steps)) {
@@ -172,15 +173,10 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
                  << "with ppp" << ((par().bc < 0) ? "a" : "p") << " boundary conditions and "
                  << par().steps << " step" << ((par().steps > 1) ? "s." : ".") << std::endl;
 
+    // set boundary conditions for gauge field
     std::vector<int> bc = {1,1,1};
     if (par().bc < 0) bc.push_back(-1);
     else bc.push_back(1);
-
-    double mTau = -1.0;
-    if(!par().maxTau.empty()) {
-        LOG(Message) << "Using adaptive algorithm with maxTau = " << par().maxTau << std::endl;
-        mTau = (double)std::stoi(par().maxTau);
-    }
 
     auto &out     = envGet(HadronsSerializable, getName());
     auto &Uresult = out.template hold<GaugeResult>();
@@ -203,46 +199,29 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
         qjwf = qj;
     }
     
+    // apply flow equations
     double time = 0;
-    Evolution<FlowAction> evolve(3.0, par().step_size, mTau, par().step_size);
-    if (mTau > 0) {
-        unsigned int step = 0;
-        do {
-            step++;
-            startTimer("gauge field step");
-            std::vector<GaugeField> Wi = evolve.template evolve_gaugeFF_adaptive<GImpl,GaugeField,GaugeLinkField>(Uwf,bc);
-            stopTimer("gauge field step");
-            evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,GaugeResult>(Uwf,Uresult,step-1);
-            if (step % par().meas_interval == 0) {
-                std::stringstream st; st << step;
-                for (int j = 0; j < par().props.size(); j++) {
-                    std::stringstream jt; jt << j;
-                    PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_q"+jt.str()+"wf");
-                    startTimer("fermion field "+jt.str()+" step");
-                    evolve.template laplace_flow<PropagatorField,GImpl,GaugeField,GaugeLinkField>(Wi[0],Wi[1],Wi[2],qjwf);
-                    stopTimer("fermion field "+jt.str()+" step");
-                    auto &qji = envGet(PropagatorField, getName()+"_q"+jt.str()+"_"+st.str());
-                    qji = qjwf;
-                }
-            }
-        } while (evolve.taus < mTau);
-    } else {
-        for (unsigned int step = 1; step <= par().steps; step++) {
-            startTimer("gauge field step");
-            std::vector<GaugeField> Wi = evolve.template evolve_gaugeFF<GImpl,GaugeField,GaugeLinkField>(Uwf,bc);
-            stopTimer("gauge field step");
-            evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,GaugeResult>(Uwf,Uresult,step-1);
-            if ((step % par().meas_interval == 0) || (step == par().steps)) {
-                std::stringstream st; st << step;
-                for (int j = 0; j < par().props.size(); j++) {
-                    std::stringstream jt; jt << j;
-                    PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_q"+jt.str()+"wf");
-                    startTimer("fermion field "+jt.str()+" step");
-                    evolve.template laplace_flow<PropagatorField,GImpl,GaugeField,GaugeLinkField>(Wi[0],Wi[1],Wi[2],qjwf);
-                    stopTimer("fermion field "+jt.str()+" step");
-                    auto &qji = envGet(PropagatorField, getName()+"_q"+jt.str()+"_"+st.str());
-                    qji = qjwf;
-                }
+    Evolution<FlowAction> evolve(3.0, par().step_size, -1.0, par().step_size);
+    for (unsigned int step = 1; step <= par().steps; step++) {
+        // evolve gauge field 
+        startTimer("gauge field flow");
+        std::vector<GaugeField> Wi = evolve.template evolve_gaugeFF<GImpl,GaugeField,GaugeLinkField>(Uwf,bc);
+        stopTimer("gauge field flow");
+
+        // measure gauge observables
+        evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,GaugeResult>(Uwf,Uresult,step-1);
+
+        // evolve propagators
+        if ((step % par().meas_interval == 0) || (step == par().steps)) {
+            std::stringstream st; st << step;
+            for (int j = 0; j < par().props.size(); j++) {
+                std::stringstream jt; jt << j;
+                PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_q"+jt.str()+"wf");
+                startTimer("fermion field "+jt.str()+" flow");
+                evolve.template laplace_flow<PropagatorField,GImpl,GaugeField,GaugeLinkField>(Wi[0],Wi[1],Wi[2],qjwf);
+                stopTimer("fermion field "+jt.str()+" flow");
+                auto &qji = envGet(PropagatorField, getName()+"_q"+jt.str()+"_"+st.str());
+                qji = qjwf;
             }
         }
     }

--- a/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
@@ -69,7 +69,10 @@ public:
                                         std::vector<double>,    clover,
                                         std::vector<double>,    topcharge,
                                         std::vector<double>,    action,
-                                        std::vector<ComplexD>,  polyakov);
+                                        std::vector<ComplexD>,  polyakovX,
+                                        std::vector<ComplexD>,  polyakovY,
+                                        std::vector<ComplexD>,  polyakovZ,
+                                        std::vector<ComplexD>,  polyakovT);
     };
 public:
     // constructor
@@ -187,7 +190,10 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
     Uresult.clover.resize(par().steps);
     Uresult.topcharge.resize(par().steps);
     Uresult.action.resize(par().steps);
-    Uresult.polyakov.resize(par().steps);
+    Uresult.polyakovX.resize(par().steps);
+    Uresult.polyakovY.resize(par().steps);
+    Uresult.polyakovZ.resize(par().steps);
+    Uresult.polyakovT.resize(par().steps);
 
     auto &U   = envGet(GaugeField, par().gauge);
     auto &Uwf = envGet(GaugeField, getName()+"_U");

--- a/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/FermionFlow.hpp
@@ -121,12 +121,13 @@ std::vector<std::string> TFermionFlow<FImpl,GImpl,FlowAction>::getOutput(void)
     {
         if ((i % par().meas_interval == 0) || (i == par().steps)) {
             double ft = par().step_size * i;
-            std::stringstream ftt; ftt << ft;
+            std::stringstream ftt; ftt << std::fixed << std::setprecision(2) << ft;
             for (std::string q : par().props) {
                 out.push_back(q+"_t"+ftt.str());
             }
         }
     }
+
     return out;
 }
 
@@ -144,9 +145,9 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::setup(void)
     // create output propagators
     for (int i = 1; i <= par().steps; i++) 
     {
-        if ((i % par().meas_interval == 0) || (i == par().steps)) {
+        if (( i % par().meas_interval == 0) || (i == par().steps)) {
             double ft = par().step_size * i;
-            std::stringstream ftt; ftt << ft;
+            std::stringstream ftt; ftt << std::fixed << std::setprecision(2) << ft;
             for (std::string q : par().props) {
                 envCreateLat(PropagatorField, q+"_t"+ftt.str());
             }
@@ -207,24 +208,25 @@ void TFermionFlow<FImpl,GImpl,FlowAction>::execute(void)
     // apply flow equations
     Evolution<FlowAction> evolve(3.0, par().step_size, -1.0, par().step_size);
     for (unsigned int step = 1; step <= par().steps; step++) {
+        double ft = par().step_size * step;
+        std::stringstream ftt; ftt << std::fixed << std::setprecision(2) << ft;
+
         // evolve gauge field 
-        startTimer("gauge field flow");
+        startTimer("gauge field flow time "+ftt.str());
         std::vector<GaugeField> Wi = evolve.template evolve_gaugeFF<GImpl,GaugeField,GaugeLinkField>(Uwf,bc);
-        stopTimer("gauge field flow");
+        stopTimer("gauge field flow time "+ftt.str());
 
         // measure gauge observables
         evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,GaugeResult>(Uwf,Uresult,step-1);
 
         // evolve propagators
-        if ((step % par().meas_interval == 0) || (step == par().steps)) {
-            double ft = par().step_size * i;
-            std::stringstream ftt; ftt << ft;
-            for (std::string q : par().props) {
-                PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_"+q+"_wf");
-                startTimer("propagator "+q+" flow");
-                evolve.template laplace_flow<PropagatorField,GImpl,GaugeField,GaugeLinkField>(Wi[0],Wi[1],Wi[2],qjwf);
-                stopTimer("propagator "+q+" flow");
-                auto &qji = envGet(PropagatorField, getName()+q+"_t"+ftt.str());
+        for (std::string q : par().props) {
+            PropagatorField &qjwf = *env().template getObject<PropagatorField>(getName()+"_tmp_"+q+"_wf");
+            startTimer("propagator "+q+" flow time "+ftt.str());
+            evolve.template laplace_flow<PropagatorField,GImpl,GaugeField,GaugeLinkField>(Wi[0],Wi[1],Wi[2],qjwf);
+            stopTimer("propagator "+q+" flow time "+ftt.str());
+            if (( step % par().meas_interval == 0) || (step == par().steps)) {
+                auto &qji = envGet(PropagatorField, q+"_t"+ftt.str());
                 qji = qjwf;
             }
         }

--- a/Hadrons/Modules/MGradientFlow/GaugeFlow.cpp
+++ b/Hadrons/Modules/MGradientFlow/GaugeFlow.cpp
@@ -1,0 +1,35 @@
+/*
+ * GaugeFlow.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2022
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Matthew Black    <matthewkblack@protonmail.com>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+#include <Hadrons/Modules/MGradientFlow/GaugeFlow.hpp>
+
+using namespace Grid;
+using namespace Hadrons;
+using namespace MGradientFlow;
+
+template class Grid::Hadrons::MGradientFlow::TGaugeFlow<GIMPL,WilsonGaugeAction<GIMPL>>;
+template class Grid::Hadrons::MGradientFlow::TGaugeFlow<GIMPL,SymanzikGaugeAction<GIMPL>>;
+template class Grid::Hadrons::MGradientFlow::TGaugeFlow<GIMPL,ZeuthenGaugeAction<GIMPL>>;

--- a/Hadrons/Modules/MGradientFlow/GaugeFlow.cpp
+++ b/Hadrons/Modules/MGradientFlow/GaugeFlow.cpp
@@ -33,3 +33,4 @@ using namespace MGradientFlow;
 template class Grid::Hadrons::MGradientFlow::TGaugeFlow<GIMPL,WilsonGaugeAction<GIMPL>>;
 template class Grid::Hadrons::MGradientFlow::TGaugeFlow<GIMPL,SymanzikGaugeAction<GIMPL>>;
 template class Grid::Hadrons::MGradientFlow::TGaugeFlow<GIMPL,ZeuthenGaugeAction<GIMPL>>;
+template class Grid::Hadrons::MGradientFlow::TGaugeFlow<GIMPL,PlaqPlusRectangleAction<GIMPL>>;

--- a/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
@@ -63,10 +63,11 @@ public:
     {
     public:
         GRID_SERIALIZABLE_CLASS_MEMBERS(Result,
+                                        std::vector<double>,    flowtime,
                                         std::vector<double>,    plaquette,
                                         std::vector<double>,    rectangle,
                                         std::vector<double>,    clover,
-                                        std::vector<double>,    topcharge,
+                                        std::vector<double>,    topocharge,
                                         std::vector<double>,    action,
                                         std::vector<ComplexD>,  polyakovX,
                                         std::vector<ComplexD>,  polyakovY,
@@ -140,42 +141,26 @@ void TGaugeFlow<GImpl,FlowAction>::runGaugeFlow(Evolution<FlowAction> &evolve, d
     auto &Uwf = envGet(GaugeField, getName()+"_U");
     Uwf = U;
 
-    if (par().steps == 0) { 
-        // if steps = 0, give the status of gauge field without flowing
-        result.plaquette.resize(1);
-        result.rectangle.resize(1);
-        result.clover.resize(1);
-        result.topcharge.resize(1);
-        result.action.resize(1);
-        result.polyakovX.resize(1);
-        result.polyakovY.resize(1);
-        result.polyakovZ.resize(1);
-        result.polyakovT.resize(1);
-        evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,Result>(Uwf,result,0); 
-    } else {
-        result.plaquette.resize(par().steps);
-        result.rectangle.resize(par().steps);
-        result.clover.resize(par().steps);
-        result.topcharge.resize(par().steps);
-        result.action.resize(par().steps);
-        result.polyakovX.resize(par().steps);
-        result.polyakovY.resize(par().steps);
-        result.polyakovZ.resize(par().steps);
-        result.polyakovT.resize(par().steps);
+    double flowt = 0.0;
+    evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,Result>(Uwf,result,flowt); 
+    // if steps = 0, give the status of gauge field without flowing
+    if (par().steps != 0) { 
         if (mTau > 0) {
             unsigned int step = 0;
             do {
                 step++;
+                flowt += evolve.epsilon;
                 evolve.template evolve_gauge_adaptive<GImpl,GaugeField>(Uwf);
                 if (step % par().meas_interval == 0) {
-                    evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,Result>(Uwf,result,step-1);
+                    evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,Result>(Uwf,result,flowt);
                 }
             } while (evolve.taus < mTau);
         } else {
             for (unsigned int step = 1; step <= par().steps; step++) {
+                flowt += evolve.epsilon;
                 evolve.template evolve_gauge<GImpl,GaugeField>(Uwf);
                 if (step % par().meas_interval == 0) {
-                    evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,Result>(Uwf,result,step-1);
+                    evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,Result>(Uwf,result,flowt);
                 }
             }
         }

--- a/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
@@ -76,7 +76,7 @@ public:
     // destructor
     virtual ~TGaugeFlow(void) {};
     // run flow
-    virtual void runGaugeFlow(Evolution<FlowAction> &evolve);
+    virtual void runGaugeFlow(Evolution<FlowAction> &evolve, double &mTau);
     virtual void setupGaugeFlow(FlowAction &SG);
     // dependency relation
     virtual std::vector<std::string> getInput(void);
@@ -128,7 +128,7 @@ void TGaugeFlow<GImpl,FlowAction>::setup(void)
 
 // run flow ////////////////////////////////////////////////////////////////////
 template <typename GImpl,typename FlowAction>
-void TGaugeFlow<GImpl,FlowAction>::runGaugeFlow(Evolution<FlowAction> &evolve)
+void TGaugeFlow<GImpl,FlowAction>::runGaugeFlow(Evolution<FlowAction> &evolve, double &mTau)
 {
     auto &out    = envGet(HadronsSerializable, getName());
     auto &result = out.template hold<Result>();
@@ -189,10 +189,10 @@ void TGaugeFlow<GImpl,FlowAction>::setupGaugeFlow(FlowAction &SG)
 
     if constexpr (std::is_same_v<FlowAction, PlaqPlusRectangleAction<GImpl>>) {
         Evolution<FlowAction> evolve(std::stod(par().c_plaq), std::stod(par().c_rect), par().step_size, mTau, par().step_size);
-        runGaugeFlow(evolve);
+        runGaugeFlow(evolve,mTau);
     } else {
         Evolution<FlowAction> evolve(3.0, par().step_size, mTau, par().step_size);
-        runGaugeFlow(evolve);
+        runGaugeFlow(evolve,mTau);
     }
 }
 

--- a/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
@@ -68,7 +68,10 @@ public:
                                         std::vector<double>,    clover,
                                         std::vector<double>,    topcharge,
                                         std::vector<double>,    action,
-                                        std::vector<ComplexD>,  polyakov);
+                                        std::vector<ComplexD>,  polyakovX,
+                                        std::vector<ComplexD>,  polyakovY,
+                                        std::vector<ComplexD>,  polyakovZ,
+                                        std::vector<ComplexD>,  polyakovT);
     };
 public:
     // constructor
@@ -144,7 +147,10 @@ void TGaugeFlow<GImpl,FlowAction>::runGaugeFlow(Evolution<FlowAction> &evolve, d
         result.clover.resize(1);
         result.topcharge.resize(1);
         result.action.resize(1);
-        result.polyakov.resize(1);
+        result.polyakovX.resize(1);
+        result.polyakovY.resize(1);
+        result.polyakovZ.resize(1);
+        result.polyakovT.resize(1);
         evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,Result>(Uwf,result,0); 
     } else {
         result.plaquette.resize(par().steps);
@@ -152,7 +158,10 @@ void TGaugeFlow<GImpl,FlowAction>::runGaugeFlow(Evolution<FlowAction> &evolve, d
         result.clover.resize(par().steps);
         result.topcharge.resize(par().steps);
         result.action.resize(par().steps);
-        result.polyakov.resize(par().steps);
+        result.polyakovX.resize(par().steps);
+        result.polyakovY.resize(par().steps);
+        result.polyakovZ.resize(par().steps);
+        result.polyakovT.resize(par().steps);
         if (mTau > 0) {
             unsigned int step = 0;
             do {

--- a/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
@@ -49,7 +49,9 @@ public:
                                     int, steps,
                                     double, step_size,
                                     int, meas_interval,
-                                    std::string, maxTau); 
+                                    std::string, maxTau,
+                                    std::string, c_plaq,
+                                    std::string, c_rect); 
 };
 
 template <typename GImpl,typename FlowAction>
@@ -78,8 +80,6 @@ public:
     virtual std::vector<std::string> getOutput(void);
     // setup
     virtual void setup(void);
-    // action
-    FlowAction SG = FlowAction(3.0);
     // execution
     virtual void execute(void);
 };
@@ -87,6 +87,7 @@ public:
 MODULE_REGISTER_TMP(WilsonFlow, ARG(TGaugeFlow<GIMPL,WilsonGaugeAction<GIMPL>>), MGradientFlow);
 MODULE_REGISTER_TMP(SymanzikFlow, ARG(TGaugeFlow<GIMPL,SymanzikGaugeAction<GIMPL>>), MGradientFlow);
 MODULE_REGISTER_TMP(ZeuthenFlow, ARG(TGaugeFlow<GIMPL,ZeuthenGaugeAction<GIMPL>>), MGradientFlow);
+MODULE_REGISTER_TMP(CustomFlow, ARG(TGaugeFlow<GIMPL,PlaqPlusRectangleAction<GIMPL>>), MGradientFlow);
 
 /******************************************************************************
  *                     TGaugeFlow implementation                          *
@@ -126,12 +127,20 @@ void TGaugeFlow<GImpl,FlowAction>::setup(void)
 template <typename GImpl,typename FlowAction>
 void TGaugeFlow<GImpl,FlowAction>::execute(void)
 {
-    std::string type = SG.action_name();
-    std::string ga = "GaugeAction";
-    std::string::size_type i = type.find(ga);
-    if (i != std::string::npos) {
-        type.erase(i, ga.length());
+    // create action -> if c_plaq and c_rect are used, called PlaqPlusRectangleAction
+    FlowAction SG;
+    if (par().c_plaq.empty() && par().c_rect.empty()) {
+        SG = createFlowAction(3.0);
+    } else {
+        if (par().c_plaq.empty() || par().c_plaq.empty()) {
+            std::cerr << "Error: to use PlaqPlusRectangleAction (CustomFlow), pass some value to both c_plaq and c_rect." << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        SG = createFlowAction(std::stod(c_plaq),std::stod(c_rect));
+        LOG(Message) << SG.LogParameters();
     }
+
+    std::string type = SG.action_name();
 
     LOG(Message) << "Setting up " << type << " Flow on '" << par().gauge << "' with " << par().steps
                  << " step" << ((par().steps != 1) ? "s." : ".") << std::endl;
@@ -139,7 +148,7 @@ void TGaugeFlow<GImpl,FlowAction>::execute(void)
     double mTau = -1.0;
     if(!par().maxTau.empty()) {
         LOG(Message) << "Using adaptive algorithm with maxTau = " << par().maxTau << std::endl;
-        mTau = (double)std::stoi(par().maxTau);
+        mTau = std::stod(par().maxTau);
     }
 
     auto &out    = envGet(HadronsSerializable, getName());

--- a/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
@@ -76,7 +76,8 @@ public:
     // destructor
     virtual ~TGaugeFlow(void) {};
     // run flow
-    virtual void runGaugeFlow(FlowAction SG);
+    virtual void runGaugeFlow(Evolution<FlowAction> &evolve);
+    virtual void setupGaugeFlow(FlowAction &SG);
     // dependency relation
     virtual std::vector<std::string> getInput(void);
     virtual std::vector<std::string> getOutput(void);
@@ -127,18 +128,8 @@ void TGaugeFlow<GImpl,FlowAction>::setup(void)
 
 // run flow ////////////////////////////////////////////////////////////////////
 template <typename GImpl,typename FlowAction>
-void TGaugeFlow<GImpl,FlowAction>::runGaugeFlow(FlowAction SG)
+void TGaugeFlow<GImpl,FlowAction>::runGaugeFlow(Evolution<FlowAction> &evolve)
 {
-    std::string type = SG.action_name();
-    LOG(Message) << "Setting up " << type << " Flow on '" << par().gauge << "' with " << par().steps
-                 << " step" << ((par().steps != 1) ? "s." : ".") << std::endl;
-
-    double mTau = -1.0;
-    if(!par().maxTau.empty()) {
-        LOG(Message) << "Using adaptive algorithm with maxTau = " << par().maxTau << std::endl;
-        mTau = std::stod(par().maxTau);
-    }
-
     auto &out    = envGet(HadronsSerializable, getName());
     auto &result = out.template hold<Result>();
 
@@ -146,11 +137,6 @@ void TGaugeFlow<GImpl,FlowAction>::runGaugeFlow(FlowAction SG)
     auto &Uwf = envGet(GaugeField, getName()+"_U");
     Uwf = U;
 
-    if constexpr (std::is_same_v<FlowAction, PlaqPlusRectangleAction<GImpl>>) {
-        Evolution<FlowAction> evolve(std::stod(par().c_plaq), std::stod(par().c_rect), par().step_size, mTau, par().step_size);
-    } else {
-        Evolution<FlowAction> evolve(3.0, par().step_size, mTau, par().step_size);
-    }
     if (par().steps == 0) { 
         // if steps = 0, give the status of gauge field without flowing
         result.plaquette.resize(1);
@@ -188,6 +174,28 @@ void TGaugeFlow<GImpl,FlowAction>::runGaugeFlow(FlowAction SG)
     saveResult(par().output,"gauge_obs",result);
 }
 
+template <typename GImpl,typename FlowAction>
+void TGaugeFlow<GImpl,FlowAction>::setupGaugeFlow(FlowAction &SG)
+{
+    std::string type = SG.action_name();
+    LOG(Message) << "Setting up " << type << " Flow on '" << par().gauge << "' with " << par().steps
+                 << " step" << ((par().steps != 1) ? "s." : ".") << std::endl;
+
+    double mTau = -1.0;
+    if(!par().maxTau.empty()) {
+        LOG(Message) << "Using adaptive algorithm with maxTau = " << par().maxTau << std::endl;
+        mTau = std::stod(par().maxTau);
+    }
+
+    if constexpr (std::is_same_v<FlowAction, PlaqPlusRectangleAction<GImpl>>) {
+        Evolution<FlowAction> evolve(std::stod(par().c_plaq), std::stod(par().c_rect), par().step_size, mTau, par().step_size);
+        runGaugeFlow(evolve);
+    } else {
+        Evolution<FlowAction> evolve(3.0, par().step_size, mTau, par().step_size);
+        runGaugeFlow(evolve);
+    }
+}
+
 // execution ///////////////////////////////////////////////////////////////////
 template <typename GImpl,typename FlowAction>
 void TGaugeFlow<GImpl,FlowAction>::execute(void)
@@ -200,10 +208,10 @@ void TGaugeFlow<GImpl,FlowAction>::execute(void)
         }
         FlowAction SG = FlowAction(std::stod(par().c_plaq),std::stod(par().c_rect));
         LOG(Message) << SG.LogParameters();
-        runGaugeFlow(SG);
+        setupGaugeFlow(SG);
     } else {
         FlowAction SG = FlowAction(3.0);
-        runGaugeFlow(SG);
+        setupGaugeFlow(SG);
     }
 }
 

--- a/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
@@ -75,6 +75,8 @@ public:
     TGaugeFlow(const std::string name);
     // destructor
     virtual ~TGaugeFlow(void) {};
+    // run flow
+    virtual void runGaugeFlow(FlowAction SG);
     // dependency relation
     virtual std::vector<std::string> getInput(void);
     virtual std::vector<std::string> getOutput(void);
@@ -123,26 +125,11 @@ void TGaugeFlow<GImpl,FlowAction>::setup(void)
     envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
-// execution ///////////////////////////////////////////////////////////////////
+// run flow ////////////////////////////////////////////////////////////////////
 template <typename GImpl,typename FlowAction>
-void TGaugeFlow<GImpl,FlowAction>::execute(void)
+void TGaugeFlow<GImpl,FlowAction>::runGaugeFlow(FlowAction SG)
 {
-    // create action -> if c_plaq and c_rect are used, called PlaqPlusRectangleAction
-    FlowAction SG;
-    if constexpr (std::is_same_v<FlowAction, PlaqPlusRectangleAction<GImpl>>) {
-        if (par().c_plaq.empty() || par().c_plaq.empty()) {
-            std::cerr << "Error: to use PlaqPlusRectangleAction (CustomFlow), pass some value to both c_plaq and c_rect." << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-        SG = FlowAction(std::stod(par().c_plaq),std::stod(par().c_rect));
-        LOG(Message) << SG.LogParameters();
-    } else {
-        SG = FlowAction(3.0);
-
-    }
-
     std::string type = SG.action_name();
-
     LOG(Message) << "Setting up " << type << " Flow on '" << par().gauge << "' with " << par().steps
                  << " step" << ((par().steps != 1) ? "s." : ".") << std::endl;
 
@@ -157,11 +144,13 @@ void TGaugeFlow<GImpl,FlowAction>::execute(void)
 
     auto &U   = envGet(GaugeField, par().gauge);
     auto &Uwf = envGet(GaugeField, getName()+"_U");
-
     Uwf = U;
-    double time = 0;
 
-    Evolution<FlowAction> evolve(3.0, par().step_size, mTau, par().step_size);
+    if constexpr (std::is_same_v<FlowAction, PlaqPlusRectangleAction<GImpl>>) {
+        Evolution<FlowAction> evolve(std::stod(par().c_plaq), std::stod(par().c_rect), par().step_size, mTau, par().step_size);
+    } else {
+        Evolution<FlowAction> evolve(3.0, par().step_size, mTau, par().step_size);
+    }
     if (par().steps == 0) { 
         // if steps = 0, give the status of gauge field without flowing
         result.plaquette.resize(1);
@@ -197,6 +186,25 @@ void TGaugeFlow<GImpl,FlowAction>::execute(void)
         }
     }
     saveResult(par().output,"gauge_obs",result);
+}
+
+// execution ///////////////////////////////////////////////////////////////////
+template <typename GImpl,typename FlowAction>
+void TGaugeFlow<GImpl,FlowAction>::execute(void)
+{
+    // create action -> if c_plaq and c_rect are used, called PlaqPlusRectangleAction
+    if constexpr (std::is_same_v<FlowAction, PlaqPlusRectangleAction<GImpl>>) {
+        if (par().c_plaq.empty() || par().c_plaq.empty()) {
+            std::cerr << "Error: to use PlaqPlusRectangleAction (CustomFlow), pass some value to both c_plaq and c_rect." << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        FlowAction SG = FlowAction(std::stod(par().c_plaq),std::stod(par().c_rect));
+        LOG(Message) << SG.LogParameters();
+        runGaugeFlow(SG);
+    } else {
+        FlowAction SG = FlowAction(3.0);
+        runGaugeFlow(SG);
+    }
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
@@ -1,0 +1,195 @@
+/*
+ * GaugeFlow.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2022
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Matthew Black    <matthewkblack@protonmail.com>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+#ifndef Hadrons_MGradientFlow_GaugeFlow_hpp_
+#define Hadrons_MGradientFlow_GaugeFlow_hpp_
+
+#include <Hadrons/Global.hpp>
+#include <Hadrons/Module.hpp>
+#include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
+#include <Hadrons/Modules/MGradientFlow/Utils.hpp>
+
+BEGIN_HADRONS_NAMESPACE
+
+/******************************************************************************
+ *                        Gauge Field Gradient Flow                           *
+ ******************************************************************************/
+BEGIN_MODULE_NAMESPACE(MGradientFlow)
+
+class GaugeFlowPar: Serializable
+{
+public:
+    GRID_SERIALIZABLE_CLASS_MEMBERS(GaugeFlowPar,
+                                    std::string, output,
+                                    std::string, gauge,
+                                    int, steps,
+                                    double, step_size,
+                                    int, meas_interval,
+                                    std::string, maxTau); 
+};
+
+template <typename GImpl,typename FlowAction>
+class TGaugeFlow: public Module<GaugeFlowPar>
+{
+public:
+    INHERIT_GIMPL_TYPES(GImpl);
+    class Result : Serializable
+    {
+    public:
+        GRID_SERIALIZABLE_CLASS_MEMBERS(Result,
+                                        std::vector<double>,    plaquette,
+                                        std::vector<double>,    rectangle,
+                                        std::vector<double>,    clover,
+                                        std::vector<double>,    topcharge,
+                                        std::vector<double>,    action,
+                                        std::vector<ComplexD>,  polyakov);
+    };
+public:
+    // constructor
+    TGaugeFlow(const std::string name);
+    // destructor
+    virtual ~TGaugeFlow(void) {};
+    // dependency relation
+    virtual std::vector<std::string> getInput(void);
+    virtual std::vector<std::string> getOutput(void);
+    // setup
+    virtual void setup(void);
+    // action
+    FlowAction SG = FlowAction(3.0);
+    // execution
+    virtual void execute(void);
+};
+
+MODULE_REGISTER_TMP(WilsonFlow, ARG(TGaugeFlow<GIMPL,WilsonGaugeAction<GIMPL>>), MGradientFlow);
+MODULE_REGISTER_TMP(SymanzikFlow, ARG(TGaugeFlow<GIMPL,SymanzikGaugeAction<GIMPL>>), MGradientFlow);
+MODULE_REGISTER_TMP(ZeuthenFlow, ARG(TGaugeFlow<GIMPL,ZeuthenGaugeAction<GIMPL>>), MGradientFlow);
+
+/******************************************************************************
+ *                     TGaugeFlow implementation                          *
+ ******************************************************************************/
+// constructor /////////////////////////////////////////////////////////////////
+template <typename GImpl,typename FlowAction>
+TGaugeFlow<GImpl,FlowAction>::TGaugeFlow(const std::string name)
+: Module<GaugeFlowPar>(name)
+{}
+
+// dependencies/products ///////////////////////////////////////////////////////
+template <typename GImpl,typename FlowAction>
+std::vector<std::string> TGaugeFlow<GImpl,FlowAction>::getInput(void)
+{
+    std::vector<std::string> in = {par().gauge};
+    
+    return in;
+}
+
+template <typename GImpl,typename FlowAction>
+std::vector<std::string> TGaugeFlow<GImpl,FlowAction>::getOutput(void)
+{
+    std::vector<std::string> out = {getName(),getName()+"_U"};
+    
+    return out;
+}
+
+// setup ///////////////////////////////////////////////////////////////////////
+template <typename GImpl,typename FlowAction>
+void TGaugeFlow<GImpl,FlowAction>::setup(void)
+{
+    envCreateLat(GaugeField, getName()+"_U");
+    envCreate(HadronsSerializable, getName(), 1, 0);
+}
+
+// execution ///////////////////////////////////////////////////////////////////
+template <typename GImpl,typename FlowAction>
+void TGaugeFlow<GImpl,FlowAction>::execute(void)
+{
+    std::string type = SG.action_name();
+    std::string ga = "GaugeAction";
+    std::string::size_type i = type.find(ga);
+    if (i != std::string::npos) {
+        type.erase(i, ga.length());
+    }
+
+    LOG(Message) << "Setting up " << type << " Flow on '" << par().gauge << "' with " << par().steps
+                 << " step" << ((par().steps != 1) ? "s." : ".") << std::endl;
+
+    double mTau = -1.0;
+    if(!par().maxTau.empty()) {
+        LOG(Message) << "Using adaptive algorithm with maxTau = " << par().maxTau << std::endl;
+        mTau = (double)std::stoi(par().maxTau);
+    }
+
+    auto &out    = envGet(HadronsSerializable, getName());
+    auto &result = out.template hold<Result>();
+
+    auto &U   = envGet(GaugeField, par().gauge);
+    auto &Uwf = envGet(GaugeField, getName()+"_U");
+
+    Uwf = U;
+    double time = 0;
+
+    Evolution<FlowAction> evolve(3.0, par().step_size, mTau, par().step_size);
+    if (par().steps == 0) { // if steps = 0, give the status of gauge field without flowing
+        result.plaquette.resize(1);
+        result.rectangle.resize(1);
+        result.clover.resize(1);
+        result.topcharge.resize(1);
+        result.action.resize(1);
+        result.polyakov.resize(1);
+        evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,Result>(Uwf,result,0); 
+    } else {
+        result.plaquette.resize(par().steps);
+        result.rectangle.resize(par().steps);
+        result.clover.resize(par().steps);
+        result.topcharge.resize(par().steps);
+        result.action.resize(par().steps);
+        result.polyakov.resize(par().steps);
+        if (mTau > 0) {
+            unsigned int step = 0;
+            do {
+                step++;
+                evolve.template evolve_gauge_adaptive<GImpl,GaugeField>(Uwf);
+                if (step % par().meas_interval == 0) {
+                    evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,Result>(Uwf,result,step-1);
+                }
+            } while (evolve.taus < mTau);
+        } else {
+            for (unsigned int step = 1; step <= par().steps; step++) {
+                evolve.template evolve_gauge<GImpl,GaugeField>(Uwf);
+                if (step % par().meas_interval == 0) {
+                    evolve.template gauge_status<GImpl,GaugeField,ComplexField,GaugeLinkField,Result>(Uwf,result,step-1);
+                }
+            }
+        }
+    }
+    saveResult(par().output,"gauge_obs",result);
+}
+
+END_MODULE_NAMESPACE
+
+END_HADRONS_NAMESPACE
+
+#endif // Hadrons_MGradientFlow_GaugeFlow_hpp_

--- a/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
@@ -129,15 +129,16 @@ void TGaugeFlow<GImpl,FlowAction>::execute(void)
 {
     // create action -> if c_plaq and c_rect are used, called PlaqPlusRectangleAction
     FlowAction SG;
-    if (par().c_plaq.empty() && par().c_rect.empty()) {
-        SG = createFlowAction(3.0);
-    } else {
+    if constexpr (std::is_same_v<FlowAction, PlaqPlusRectangleAction<GImpl>>) {
         if (par().c_plaq.empty() || par().c_plaq.empty()) {
             std::cerr << "Error: to use PlaqPlusRectangleAction (CustomFlow), pass some value to both c_plaq and c_rect." << std::endl;
             std::exit(EXIT_FAILURE);
         }
-        SG = createFlowAction(std::stod(c_plaq),std::stod(c_rect));
+        SG = FlowAction(std::stod(par().c_plaq),std::stod(par().c_rect));
         LOG(Message) << SG.LogParameters();
+    } else {
+        SG = FlowAction(3.0);
+
     }
 
     std::string type = SG.action_name();

--- a/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
+++ b/Hadrons/Modules/MGradientFlow/GaugeFlow.hpp
@@ -152,7 +152,8 @@ void TGaugeFlow<GImpl,FlowAction>::execute(void)
     double time = 0;
 
     Evolution<FlowAction> evolve(3.0, par().step_size, mTau, par().step_size);
-    if (par().steps == 0) { // if steps = 0, give the status of gauge field without flowing
+    if (par().steps == 0) { 
+        // if steps = 0, give the status of gauge field without flowing
         result.plaquette.resize(1);
         result.rectangle.resize(1);
         result.clover.resize(1);

--- a/Hadrons/Modules/MGradientFlow/Utils.hpp
+++ b/Hadrons/Modules/MGradientFlow/Utils.hpp
@@ -119,7 +119,7 @@ double avgClover(const GaugeLorentz &Umu)
 }
 
 // polyakov loop in mu direction  //////////////////////////////////////////////
-template <typename GImpl, GaugeField, GaugeLinkField>
+template <typename GImpl, typename GaugeField, typename GaugeLinkField>
 ComplexD avgPolyakovLoopMu(const GaugeField &Umu, int mu) { // assuming Nd=4
     GaugeLinkField Ut(Umu.Grid()), P(Umu.Grid);
     ComplexD out;
@@ -308,7 +308,7 @@ class Evolution {
             ComplexD polyX = avgPolyakovLoopMu<GImpl,GaugeField,GaugeLinkField>(Umu,0);
             ComplexD polyY = avgPolyakovLoopMu<GImpl,GaugeField,GaugeLinkField>(Umu,1);
             ComplexD polyZ = avgPolyakovLoopMu<GImpl,GaugeField,GaugeLinkField>(Umu,2);
-            ComplexD polyY = avgPolyakovLoopMu<GImpl,GaugeField,GaugeLinkField>(Umu,3);
+            ComplexD polyT = avgPolyakovLoopMu<GImpl,GaugeField,GaugeLinkField>(Umu,3);
 
             result.plaquette[index]  = plaq;
             result.rectangle[index]  = rect;

--- a/Hadrons/Modules/MGradientFlow/Utils.hpp
+++ b/Hadrons/Modules/MGradientFlow/Utils.hpp
@@ -1,0 +1,312 @@
+/*
+ * Utils.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2022
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Matthew Black    <matthewkblack@protonmail.com>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+#ifndef Hadrons_MGradientFlow_Utils_hpp_
+#define Hadrons_MGradientFlow_Utils_hpp_
+
+#include <Hadrons/Global.hpp>
+#include <Hadrons/Module.hpp>
+
+BEGIN_HADRONS_NAMESPACE
+
+BEGIN_MODULE_NAMESPACE(MGradientFlow)
+
+// additional action(s) /////////////////////////////////////////////////////
+template <class GImpl>
+class ZeuthenGaugeAction {
+public:
+    INHERIT_GIMPL_TYPES(GImpl);
+    
+    double beta;
+    SymanzikGaugeAction<GImpl> SG;
+
+    ZeuthenGaugeAction(double b): beta(b),SG(SymanzikGaugeAction<GImpl>(b)) {};
+
+    virtual std::string action_name(){return "ZeuthenGaugeAction";}
+
+    virtual double S(const GaugeField &U) {
+        return SG.S(U);
+    };
+
+    virtual void deriv(const GaugeField &Umu, GaugeField &dSdU) {
+                                                //  beta = 3.0, cl = -1.0/12.0 -> Symanzik
+        double factor_p = 5.0/double(Nc)*0.5;   //   5.0 = beta*(1.0-8.0*cl)
+        double factor_r = -0.25/double(Nc)*0.5; // -0.25 = beta*cl
+
+        GridBase *grid = Umu.Grid();
+
+        std::vector<GaugeLinkField> U (Nd,grid);
+        std::vector<GaugeLinkField> U2(Nd,grid);
+
+        for(int mu=0;mu<Nd;mu++){
+            U[mu] = PeekIndex<LorentzIndex>(Umu,mu);
+            WilsonLoops<GImpl>::RectStapleDouble(U2[mu],U[mu],mu);
+        }
+
+        GaugeLinkField dSdU_mu(grid);
+        GaugeLinkField staple(grid);
+        GaugeLinkField tmp(grid),tmq(grid),tmr(grid);
+
+        for (int mu=0; mu < Nd; mu++){
+            // Staple in direction mu
+            WilsonLoops<GImpl>::Staple(staple,Umu,mu);
+            tmp = Ta(U[mu]*staple)*factor_p;
+
+            WilsonLoops<GImpl>::RectStaple(Umu,staple,U2,U,mu);
+            tmp = tmp + Ta(U[mu]*staple)*factor_r;
+
+            tmq = (adj(Cshift(U[mu],mu,-1)) * Cshift(tmp,mu,-1) * Cshift(U[mu],mu,-1));
+            tmr = (U[mu] * Cshift(tmp,mu,1) * adj(U[mu]));
+
+            dSdU_mu = 5.0/6.0*tmp + 1.0/12.0*tmq + 1.0/12.0*tmr;
+            PokeIndex<LorentzIndex>(dSdU, dSdU_mu, mu);
+        }
+    };
+};
+
+// clover //////////////////////////////////////////////////////////////////////
+template <typename GImpl, typename ComplexField, typename GaugeLorentz, typename GaugeMat>
+void siteClover(ComplexField &Clov, const GaugeLorentz &U)
+{
+    GaugeMat Fmn(U.Grid()), Cmn(U.Grid()), scaledUnit(U.Grid()), Umu(U.Grid());
+    Clov = Zero();
+    for (int mu = 1; mu < Nd; mu++) {
+        for (int nu = 0; nu < mu; nu++) {
+            Umu = PeekIndex<LorentzIndex>(U, mu);
+            scaledUnit = (1.0/Nc) * (adj(Umu) * Umu);
+            WilsonLoops<GImpl>::FieldStrength(Fmn, U, mu, nu);
+            Cmn = Fmn - trace(Fmn) * scaledUnit;
+            Clov = Clov - trace(Cmn * Cmn);
+        }
+    }
+}
+
+template <typename GImpl, typename ComplexField, typename GaugeLorentz, typename GaugeMat>
+double avgClover(const GaugeLorentz &Umu) 
+{
+    ComplexField Clov(Umu.Grid());
+
+    siteClover<GImpl,ComplexField,GaugeLorentz,GaugeMat>(Clov, Umu);
+    auto Tc = sum(Clov);
+    auto c = TensorRemove(Tc);
+
+    double vol = Umu.Grid()->gSites();
+
+    return c.real() / vol;
+}
+
+// field evolution /////////////////////////////////////////////////////////////
+template <typename FlowAction>
+class Evolution {
+    public:
+        double epsilon, maxTau, taus;
+        FlowAction SG;
+        Evolution(double beta, double step, double mTau, double ts) : 
+            SG(FlowAction(beta)), epsilon(step), maxTau(mTau), taus(ts) {};
+
+        template <typename GImpl,typename GaugeField>
+        std::vector<GaugeField> gauge_RK(GaugeField U) {
+
+            std::vector<GaugeField> Wi;
+
+            GaugeField Z(U.Grid());
+            GaugeField tmp(U.Grid());
+            Wi.push_back(U);                            // W0
+            SG.deriv(U, Z);                                
+            Z *= 0.25;                                  // Z0 = 1/4 * F(U)
+            GImpl::update_field(Z, U, -2.0*epsilon);    // U = W1 = exp(ep*Z0)*W0
+            Wi.push_back(U);                            // W1
+
+            Z *= -17.0/8.0;
+            SG.deriv(U, tmp); Z += tmp;                 // -17/32*Z0 + Z1
+            Z *= 8.0/9.0;                               // Z = -17/36*Z0 +8/9*Z1
+            GImpl::update_field(Z, U, -2.0*epsilon);    // U_= W2 = exp(ep*Z)*W1
+            Wi.push_back(U);                            // W2
+
+            Z *= -4.0/3.0;
+            SG.deriv(U, tmp); Z += tmp;                 // 4/3*(17/36*Z0 -8/9*Z1) + Z2
+            Z *= 3.0/4.0;                               // Z = 17/36*Z0 -8/9*Z1 +3/4*Z2
+            GImpl::update_field(Z, U, -2.0*epsilon);    // V(t+e) = exp(ep*Z)*W2
+            Wi.push_back(U);                            // W3
+
+            return Wi;
+        };
+
+        template <typename GImpl,typename GaugeField>
+        std::vector<GaugeField> gauge_RK_adaptive(GaugeField U) {
+
+            std::vector<GaugeField> Wi;
+
+            if (maxTau - taus < epsilon){
+                epsilon = maxTau-taus;
+            }
+            GaugeField Z(U.Grid());
+            GaugeField Zprime(U.Grid());
+            GaugeField tmp(U.Grid()), Uprime(U.Grid());
+            Uprime = U;
+            Wi.push_back(U);                            // W0
+            SG.deriv(U, Z);
+            Zprime = -Z;
+            Z *= 0.25;                                  // Z0 = 1/4 * F(U)
+            GImpl::update_field(Z, U, -2.0*epsilon);    // U = W1 = exp(ep*Z0)*W0
+            Wi.push_back(U);                            // W1
+
+            Z *= -17.0/8.0;
+            SG.deriv(U, tmp); Z += tmp;                 // -17/32*Z0 +Z1
+            Zprime += 2.0*tmp;
+            Z *= 8.0/9.0;                               // Z = -17/36*Z0 +8/9*Z1
+            GImpl::update_field(Z, U, -2.0*epsilon);    // U_= W2 = exp(ep*Z)*W1
+            Wi.push_back(U);                            // W2
+
+            Z *= -4.0/3.0;
+            SG.deriv(U, tmp); Z += tmp;                 // 4/3*(17/36*Z0 -8/9*Z1) +Z2
+            Z *= 3.0/4.0;                               // Z = 17/36*Z0 -8/9*Z1 +3/4*Z2
+            GImpl::update_field(Z, U, -2.0*epsilon);    // V(t+e) = exp(ep*Z)*W2      
+            Wi.push_back(U);                            // W3
+            
+            GImpl::update_field(Zprime, Uprime, -2.0*epsilon); // V'(t+e) = exp(ep*Z')*W0
+            Wi.push_back(Uprime);                       // Uprime
+
+            return Wi;
+        };
+
+        template <typename GaugeField>
+        void adaptive_eps(const GaugeField& U, const GaugeField& Uprime) {
+            // Compute distance as norm^2 of the difference
+            GaugeField diffU = U - Uprime;
+            double diff = norm2(diffU);   
+            // adjust integration step  
+
+            taus += epsilon;
+            epsilon = epsilon*0.95*std::pow(1e-4/diff,1./3.);
+        };
+
+        template <typename GImpl,typename GaugeField>
+        void evolve_gauge(GaugeField &U) {
+            std::vector<GaugeField> Wi = gauge_RK<GImpl,GaugeField>(U);
+            U = Wi[3];
+        };
+
+        template <typename GImpl,typename GaugeField>
+        void evolve_gauge_adaptive(GaugeField &U) {
+            std::vector<GaugeField> Wi = gauge_RK_adaptive<GImpl,GaugeField>(U);
+            adaptive_eps(Wi[3],Wi[4]);
+            U = Wi[3];
+        };
+
+        template <typename GaugeField,typename GaugeLinkField>
+        void gauge_apply_boundary(GaugeField &Umu, std::vector<int> bc) {
+            GaugeLinkField tmp1(Umu.Grid());
+            GaugeLinkField tmp2(Umu.Grid());
+            GaugeLinkField tmp3(Umu.Grid());
+            Lattice<iScalar<vInteger>> coord(Umu.Grid());
+
+            for (int mu = 0; mu < Nd; mu++) {
+                LatticeCoordinate(coord,mu);
+                
+                tmp1 = PeekIndex<LorentzIndex>(Umu,mu);
+                tmp2 = (double)bc[mu]*tmp1;
+                int dimSize = Umu.Grid()->GlobalDimensions()[mu] - 1;
+                tmp3 = where((coord == dimSize), tmp2, tmp1);
+                PokeIndex<LorentzIndex>(Umu, tmp3, mu);
+            }
+        };
+
+        template <typename FImpl,typename GImpl,typename GaugeField,typename GaugeLinkField>
+        FImpl generic_laplace(double a, double b, GaugeField &Umu, const FImpl& x_in, int skip_axis) {
+            double Nx = Nd;
+            if (skip_axis != -1) Nx--;
+
+            FImpl x_out = (a + -2.0*Nx*b) * x_in;
+            for (int mu = 0; mu < Nd; mu++) {
+                if (mu != skip_axis) {
+                    GaugeLinkField U = PeekIndex<LorentzIndex>(Umu, mu);
+                    x_out += b*(GImpl::CovShiftForward(U,mu,x_in) + GImpl::CovShiftBackward(U,mu,x_in));
+                }
+            }
+            return x_out;
+        };
+
+        template <typename FImpl,typename GImpl,typename GaugeField,typename GaugeLinkField>
+        void laplace_flow(GaugeField &W0, GaugeField &W1, GaugeField &W2, FImpl &prop) {
+            FImpl psi1 = prop + (epsilon/4.0)*generic_laplace<FImpl,GImpl,GaugeField,GaugeLinkField>(0.0, 1.0, W0, prop, -1);
+            FImpl psi2 = prop + (8.0*epsilon/9.0)*generic_laplace<FImpl,GImpl,GaugeField,GaugeLinkField>(0.0, 1.0, W1, psi1, -1) - (2.0*epsilon/9.0)*generic_laplace<FImpl,GImpl,GaugeField,GaugeLinkField>(0.0, 1.0, W0, prop, -1);
+            FImpl psi3 = psi1 + (3.0*epsilon/4.0)*generic_laplace<FImpl,GImpl,GaugeField,GaugeLinkField>(0.0, 1.0, W2, psi2, -1);
+
+            prop = psi3;
+        };
+
+        template <typename GImpl,typename GaugeField,typename GaugeLinkField>
+        std::vector<GaugeField> evolve_gaugeFF(GaugeField &U, std::vector<int> &bc) {
+            std::vector<GaugeField> Wi = gauge_RK<GImpl,GaugeField>(U);
+            U = 1.0*Wi[3];
+
+            gauge_apply_boundary<GaugeField,GaugeLinkField>(Wi[0],bc);
+            gauge_apply_boundary<GaugeField,GaugeLinkField>(Wi[1],bc);
+            gauge_apply_boundary<GaugeField,GaugeLinkField>(Wi[2],bc);
+
+            return Wi;
+        };
+
+        template <typename GImpl,typename GaugeField,typename GaugeLinkField>
+        std::vector<GaugeField> evolve_gaugeFF_adaptive(GaugeField &U, std::vector<int> &bc) {
+            std::vector<GaugeField> Wi = gauge_RK_adaptive<GImpl,GaugeField>(U);
+            U = 1.0*Wi[3];
+
+            gauge_apply_boundary<GaugeField,GaugeLinkField>(Wi[0],bc);
+            gauge_apply_boundary<GaugeField,GaugeLinkField>(Wi[1],bc);
+            gauge_apply_boundary<GaugeField,GaugeLinkField>(Wi[2],bc);
+            
+            adaptive_eps(Wi[3],Wi[4]);
+
+            return Wi;
+        };
+        
+        // gauge field status //////////////////////////////////////////////////////////
+        template <typename GImpl,typename GaugeField,typename ComplexField,typename GaugeLinkField,typename Result>
+        void gauge_status(GaugeField &Umu, Result &result, int index)
+        {
+            double Q = WilsonLoops<GImpl>::TopologicalCharge(Umu);
+            double plaq = WilsonLoops<GImpl>::avgPlaquette(Umu);
+            double rect = WilsonLoops<GImpl>::avgRectangle(Umu);
+            double clov = avgClover<GImpl,ComplexField,GaugeField,GaugeLinkField>(Umu);
+            double act = SG.S(Umu);
+            ComplexD poly = WilsonLoops<GImpl>::avgPolyakovLoop(Umu);
+
+            result.plaquette[index] = plaq;
+            result.rectangle[index] = rect;
+            result.clover[index]    = clov;
+            result.topcharge[index] =    Q;
+            result.action[index]    =  act;
+            result.polyakov[index]  = poly;
+        };
+};
+
+END_MODULE_NAMESPACE
+
+END_HADRONS_NAMESPACE
+
+#endif // Hadrons_MGradientFlow_Utils_hpp_

--- a/Hadrons/Modules/MGradientFlow/Utils.hpp
+++ b/Hadrons/Modules/MGradientFlow/Utils.hpp
@@ -271,20 +271,6 @@ class Evolution {
             return Wi;
         };
 
-        template <typename GImpl,typename GaugeField,typename GaugeLinkField>
-        std::vector<GaugeField> evolve_gaugeFF_adaptive(GaugeField &U, std::vector<int> &bc) {
-            std::vector<GaugeField> Wi = gauge_RK_adaptive<GImpl,GaugeField>(U);
-            U = 1.0*Wi[3];
-
-            gauge_apply_boundary<GaugeField,GaugeLinkField>(Wi[0],bc);
-            gauge_apply_boundary<GaugeField,GaugeLinkField>(Wi[1],bc);
-            gauge_apply_boundary<GaugeField,GaugeLinkField>(Wi[2],bc);
-            
-            adaptive_eps(Wi[3],Wi[4]);
-
-            return Wi;
-        };
-        
         // gauge field status //////////////////////////////////////////////////////////
         template <typename GImpl,typename GaugeField,typename ComplexField,typename GaugeLinkField,typename Result>
         void gauge_status(GaugeField &Umu, Result &result, int index)

--- a/Hadrons/Modules/MGradientFlow/Utils.hpp
+++ b/Hadrons/Modules/MGradientFlow/Utils.hpp
@@ -298,7 +298,7 @@ class Evolution {
 
         // gauge field status //////////////////////////////////////////////////////////
         template <typename GImpl,typename GaugeField,typename ComplexField,typename GaugeLinkField,typename Result>
-        void gauge_status(GaugeField &Umu, Result &result, int index)
+        void gauge_status(GaugeField &Umu, Result &result, double flowt)
         {
             double Q = WilsonLoops<GImpl>::TopologicalCharge(Umu);
             double plaq = WilsonLoops<GImpl>::avgPlaquette(Umu);
@@ -310,15 +310,16 @@ class Evolution {
             ComplexD polyZ = avgPolyakovLoopMu<GImpl,GaugeField,GaugeLinkField>(Umu,2);
             ComplexD polyT = avgPolyakovLoopMu<GImpl,GaugeField,GaugeLinkField>(Umu,3);
 
-            result.plaquette[index]  = plaq;
-            result.rectangle[index]  = rect;
-            result.clover[index]     = clov;
-            result.topcharge[index]  =    Q;
-            result.action[index]     =  act;
-            result.polyakovX[index]  = polyX;
-            result.polyakovY[index]  = polyY;
-            result.polyakovZ[index]  = polyZ;
-            result.polyakovT[index]  = polyT;
+            result.flowtime.push_back(flowt);
+            result.plaquette.push_back(plaq);
+            result.rectangle.push_back(rect);
+            result.clover.push_back(clov);
+            result.topocharge.push_back(Q);
+            result.action.push_back(act);
+            result.polyakovX.push_back(polyX);
+            result.polyakovY.push_back(polyY);
+            result.polyakovZ.push_back(polyZ);
+            result.polyakovT.push_back(polyT);
         };
 };
 

--- a/Hadrons/Modules/MGradientFlow/Utils.hpp
+++ b/Hadrons/Modules/MGradientFlow/Utils.hpp
@@ -121,7 +121,7 @@ double avgClover(const GaugeLorentz &Umu)
 // polyakov loop in mu direction  //////////////////////////////////////////////
 template <typename GImpl, typename GaugeField, typename GaugeLinkField>
 ComplexD avgPolyakovLoopMu(const GaugeField &Umu, int mu) { // assuming Nd=4
-    GaugeLinkField Ut(Umu.Grid()), P(Umu.Grid);
+    GaugeLinkField Ut(Umu.Grid()), P(Umu.Grid());
     ComplexD out;
 
     double vol = Umu.Grid()->gSites();

--- a/Hadrons/Modules/MGradientFlow/Utils.hpp
+++ b/Hadrons/Modules/MGradientFlow/Utils.hpp
@@ -34,17 +34,6 @@ BEGIN_HADRONS_NAMESPACE
 
 BEGIN_MODULE_NAMESPACE(MGradientFlow)
 
-// handle actions with different args ///////////////////////////////////////
-template <typename FlowAction, typename Arg1, typename Arg2>
-FlowAction createFlowAction(Arg1&& a, Arg2&& b) {
-    if constexpr (std::is_constructible_v<FlowAction, Arg1, Arg2>) {
-        // FlowAction can be constructed with two arguments for PlaqPlusRectangle : c_plaq, c_rect
-        return FlowAction(std::forward<Arg1>(a), std::forward<Arg2>(b));
-    } else { // other actions use only beta as arg
-        return FlowAction(std::forward<Arg1>(a));
-    }
-}
-
 // additional action(s) /////////////////////////////////////////////////////
 template <class GImpl>
 class ZeuthenGaugeAction {

--- a/Hadrons/Modules/MGradientFlow/Utils.hpp
+++ b/Hadrons/Modules/MGradientFlow/Utils.hpp
@@ -118,6 +118,24 @@ double avgClover(const GaugeLorentz &Umu)
     return c.real() / vol;
 }
 
+// polyakov loop in mu direction  //////////////////////////////////////////////
+template <typename GImpl, GaugeField, GaugeLinkField>
+ComplexD avgPolyakovLoopMu(const GaugeField &Umu, int mu) { // assuming Nd=4
+    GaugeLinkField Ut(Umu.Grid()), P(Umu.Grid);
+    ComplexD out;
+
+    double vol = Umu.Grid()->gSites();
+
+    Ut = peekLorentz(Umu,mu);
+    P = Ut;
+    for (int t=1; t < Umu.Grid()->GlobalDimensions()[mu]; t++) {
+        P = GImpl::CovShiftForward(Ut,mu,P);
+    }
+    RealD norm = 1.0/(Nc*vol);
+    out = sum(trace(P))*norm;
+    return out;
+}
+
 // field evolution /////////////////////////////////////////////////////////////
 template <typename FlowAction>
 class Evolution {
@@ -287,14 +305,20 @@ class Evolution {
             double rect = WilsonLoops<GImpl>::avgRectangle(Umu);
             double clov = avgClover<GImpl,ComplexField,GaugeField,GaugeLinkField>(Umu);
             double act = SG.S(Umu);
-            ComplexD poly = WilsonLoops<GImpl>::avgPolyakovLoop(Umu);
+            ComplexD polyX = avgPolyakovLoopMu<GImpl,GaugeField,GaugeLinkField>(Umu,0);
+            ComplexD polyY = avgPolyakovLoopMu<GImpl,GaugeField,GaugeLinkField>(Umu,1);
+            ComplexD polyZ = avgPolyakovLoopMu<GImpl,GaugeField,GaugeLinkField>(Umu,2);
+            ComplexD polyY = avgPolyakovLoopMu<GImpl,GaugeField,GaugeLinkField>(Umu,3);
 
-            result.plaquette[index] = plaq;
-            result.rectangle[index] = rect;
-            result.clover[index]    = clov;
-            result.topcharge[index] =    Q;
-            result.action[index]    =  act;
-            result.polyakov[index]  = poly;
+            result.plaquette[index]  = plaq;
+            result.rectangle[index]  = rect;
+            result.clover[index]     = clov;
+            result.topcharge[index]  =    Q;
+            result.action[index]     =  act;
+            result.polyakovX[index]  = polyX;
+            result.polyakovY[index]  = polyY;
+            result.polyakovZ[index]  = polyZ;
+            result.polyakovT[index]  = polyT;
         };
 };
 

--- a/Hadrons/Modules/MGradientFlow/Utils.hpp
+++ b/Hadrons/Modules/MGradientFlow/Utils.hpp
@@ -34,6 +34,17 @@ BEGIN_HADRONS_NAMESPACE
 
 BEGIN_MODULE_NAMESPACE(MGradientFlow)
 
+// handle actions with different args ///////////////////////////////////////
+template <typename FlowAction, typename Arg1, typename Arg2>
+FlowAction createFlowAction(Arg1&& a, Arg2&& b) {
+    if constexpr (std::is_constructible_v<FlowAction, Arg1, Arg2>) {
+        // FlowAction can be constructed with two arguments for PlaqPlusRectangle : c_plaq, c_rect
+        return FlowAction(std::forward<Arg1>(a), std::forward<Arg2>(b));
+    } else { // other actions use only beta as arg
+        return FlowAction(std::forward<Arg1>(a));
+    }
+}
+
 // additional action(s) /////////////////////////////////////////////////////
 template <class GImpl>
 class ZeuthenGaugeAction {
@@ -124,8 +135,15 @@ class Evolution {
     public:
         double epsilon, maxTau, taus;
         FlowAction SG;
+
+        // constructor with beta
         Evolution(double beta, double step, double mTau, double ts) : 
             SG(FlowAction(beta)), epsilon(step), maxTau(mTau), taus(ts) {};
+
+        // constructor with c_plaq, c_rect
+        Evolution(double c_plaq, double c_rect, double step, double mTau, double ts) : 
+            SG(FlowAction(c_plaq, c_rect)), epsilon(step), maxTau(mTau), taus(ts) {};
+
 
         template <typename GImpl,typename GaugeField>
         std::vector<GaugeField> gauge_RK(GaugeField U) {

--- a/tests/Make.inc
+++ b/tests/Make.inc
@@ -1,5 +1,5 @@
-tests-local: Test_QED_Local Test_QED Test_diskvector Test_exact_distil Test_free_prop Test_hadrons_meson_3pt Test_hadrons_spectrum Test_sigma_to_nucleon Test_stoch_distil Test_xi_to_sigma
-EXTRA_PROGRAMS = Test_QED_Local Test_QED Test_diskvector Test_exact_distil Test_free_prop Test_hadrons_meson_3pt Test_hadrons_spectrum Test_sigma_to_nucleon Test_stoch_distil Test_xi_to_sigma
+tests-local: Test_QED_Local Test_QED Test_diskvector Test_exact_distil Test_fermion_flow Test_free_prop Test_gradient_flow Test_hadrons_meson_3pt Test_hadrons_spectrum Test_sigma_to_nucleon Test_stoch_distil Test_xi_to_sigma
+EXTRA_PROGRAMS = Test_QED_Local Test_QED Test_diskvector Test_exact_distil Test_fermion_flow Test_free_prop Test_gradient_flow Test_hadrons_meson_3pt Test_hadrons_spectrum Test_sigma_to_nucleon Test_stoch_distil Test_xi_to_sigma
 
 Test_QED_Local_SOURCES=Test_QED.cc
 Test_QED_LDADD=-lHadrons -lGrid
@@ -13,8 +13,14 @@ Test_diskvector_LDADD=-lHadrons -lGrid
 Test_exact_distil_SOURCES=Test_exact_distil.cc
 Test_exact_distil_LDADD=-lHadrons -lGrid
 
+Test_fermion_flow_SOURCES=Test_fermion_flow.cc
+Test_fermion_flow_LDADD=-lHadrons -lGrid
+
 Test_free_prop_SOURCES=Test_free_prop.cc
 Test_free_prop_LDADD=-lHadrons -lGrid
+
+Test_gradient_flow_SOURCES=Test_gradient_flow.cc
+Test_gradient_flow_LDADD=-lHadrons -lGrid
 
 Test_hadrons_meson_3pt_SOURCES=Test_hadrons_meson_3pt.cc
 Test_hadrons_meson_3pt_LDADD=-lHadrons -lGrid
@@ -31,5 +37,5 @@ Test_stoch_distil_LDADD=-lHadrons -lGrid
 Test_xi_to_sigma_SOURCES=Test_xi_to_sigma.cc
 Test_xi_to_sigma_LDADD=-lHadrons -lGrid
 
-CLEANFILES = Test_QED_Local Test_QED Test_diskvector Test_exact_distil Test_free_prop Test_hadrons_meson_3pt Test_hadrons_spectrum Test_sigma_to_nucleon Test_stoch_distil Test_xi_to_sigma
+CLEANFILES = Test_QED_Local Test_QED Test_diskvector Test_exact_distil Test_fermion_flow Test_free_prop Test_gradient_flow Test_hadrons_meson_3pt Test_hadrons_spectrum Test_sigma_to_nucleon Test_stoch_distil Test_xi_to_sigma
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,8 +9,10 @@ EXTRA_PROGRAMS = \
   Test_diskvector           \
   Test_em_field             \
   Test_exact_distil         \
+  Test_fermion_flow			\
   Test_field_io             \
   Test_free_prop            \
+  Test_gradient_flow		\
   Test_hadrons_meson_3pt    \
   Test_hadrons_spectrum     \
   Test_highfreq_stat        \
@@ -44,11 +46,17 @@ Test_em_field_LDADD=-lHadrons -lGrid
 Test_exact_distil_SOURCES=Test_exact_distil.cpp
 Test_exact_distil_LDADD=-lHadrons -lGrid
 
+Test_fermion_flow_SOURCES=Test_fermion_flow.cpp
+Test_fermion_flow_LDADD=-lHadrons -lGrid
+
 Test_field_io_SOURCES=Test_field_io.cpp
 Test_field_io_LDADD=-lHadrons -lGrid
 
 Test_free_prop_SOURCES=Test_free_prop.cpp
 Test_free_prop_LDADD=-lHadrons -lGrid
+
+Test_gradient_flow_SOURCES=Test_gradient_flow.cpp
+Test_gradient_flow_LDADD=-lHadrons -lGrid
 
 Test_hadrons_meson_3pt_SOURCES=Test_hadrons_meson_3pt.cpp
 Test_hadrons_meson_3pt_LDADD=-lHadrons -lGrid

--- a/tests/Test_fermion_flow.cpp
+++ b/tests/Test_fermion_flow.cpp
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
     wfPar.step_size = 0.01;                  // size of one step in flow time/a^2
     wfPar.meas_interval = 10;                // interval of steps at which to measure observables
     wfPar.props = qName;                     // provide a list of propagators to be flowed
-    //wfPar.outPropStems = {"flowedquark1"}; // (optional) provide a list of stems to assign the output propagators + "_tXXX" flow time value
+    //wfPar.outProps = {"flowedquark1"};     // (optional) provide a list of names for the output propagators
     wfPar.bc = -1;                           // set boundary conditions to anti-periodic in time (bc = 1 will keep periodic)
     //wfPar.output = "GaugeFlow";            // option to output gauge flow data separately
     application.createModule<MGradientFlow::WilsonFermionFlow>("FermionFlow",wfPar);

--- a/tests/Test_fermion_flow.cpp
+++ b/tests/Test_fermion_flow.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
     MGradientFlow::WilsonFermionFlow::Par wfPar;
     wfPar.gauge = "gauge";
     wfPar.steps = 10;                     // total number of evolution steps to perform
-    wfPar.step_size = 0.1;                // size of one step in flow time/a^2
+    wfPar.step_size = 0.01;               // size of one step in flow time/a^2
     wfPar.meas_interval = 10;              // interval of steps at which to measure observables
     wfPar.props = qName;                  // provide a list of propagators to be flowed
     wfPar.bc = -1;                        // set boundary conditions to anti-periodic in time (bc = 1 will keep periodic)
@@ -98,8 +98,8 @@ int main(int argc, char *argv[])
     
     // positive flow contractions
     MContraction::Meson::Par mesflowPar;
-    mesflowPar.q1     = qName[0]+"_t1.00";
-    mesflowPar.q2     = qName[0]+"_t1.00";
+    mesflowPar.q1     = qName[0]+"_t0.10";
+    mesflowPar.q2     = qName[0]+"_t0.10";
     mesflowPar.gammas = "all";
     mesflowPar.sink   = "sink";
     application.createModule<MContraction::Meson>("meson_t0.10",mesflowPar);

--- a/tests/Test_fermion_flow.cpp
+++ b/tests/Test_fermion_flow.cpp
@@ -98,8 +98,8 @@ int main(int argc, char *argv[])
     
     // positive flow contractions
     MContraction::Meson::Par mesflowPar;
-    mesflowPar.q1     = "FermionFlow_q0_10";
-    mesflowPar.q2     = "FermionFlow_q0_10";
+    mesflowPar.q1     = qName[0]+"_t1.00";
+    mesflowPar.q2     = qName[0]+"_t1.00";
     mesflowPar.gammas = "all";
     mesflowPar.sink   = "sink";
     application.createModule<MContraction::Meson>("meson_t0.10",mesflowPar);

--- a/tests/Test_fermion_flow.cpp
+++ b/tests/Test_fermion_flow.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
     MSource::Point::Par ptPar;
     ptPar.position = "0 0 0 0";
     std:: string srcName  = "pt_0";
-    application.createModule<MSource::Point>(srcName, z2Par);
+    application.createModule<MSource::Point>(srcName, ptPar);
 
     // point sink
     MSink::Point::Par sinkPar;
@@ -93,16 +93,16 @@ int main(int argc, char *argv[])
     wfPar.props = qName;                  // provide a list of propagators to be flowed
     wfPar.bc = -1;                        // set boundary conditions to anti-periodic in time (bc = 1 will keep periodic)
     //wfPar.output = "GaugeFlow";         // option to output gauge flow data separately
-    application.createModule<MGradientFlow::WilsonFermionFlow>("FermionFlow",gfPar);
+    application.createModule<MGradientFlow::WilsonFermionFlow>("FermionFlow",wfPar);
     // ///////////////////////////////////////////////////////////////////////
     
     // positive flow contractions
-    MContraction::Meson::Par mesPar;
-    mesPar.q1     = "FermionFlow_q0_10";
-    mesPar.q2     = "FermionFlow_q0_10";
-    mesPar.gammas = "all";
-    mesPar.sink   = "sink";
-    application.createModule<MContraction::Meson>("meson_t0.10",mesPar);
+    MContraction::Meson::Par mesflowPar;
+    mesflowPar.q1     = "FermionFlow_q0_10";
+    mesflowPar.q2     = "FermionFlow_q0_10";
+    mesflowPar.gammas = "all";
+    mesflowPar.sink   = "sink";
+    application.createModule<MContraction::Meson>("meson_t0.10",mesflowPar);
     results.push_back("meson_t0.10");
 
     // save data

--- a/tests/Test_fermion_flow.cpp
+++ b/tests/Test_fermion_flow.cpp
@@ -87,12 +87,13 @@ int main(int argc, char *argv[])
     // gradient flow on propagator ///////////////////////////////////////////
     MGradientFlow::WilsonFermionFlow::Par wfPar;
     wfPar.gauge = "gauge";
-    wfPar.steps = 10;                     // total number of evolution steps to perform
-    wfPar.step_size = 0.01;               // size of one step in flow time/a^2
-    wfPar.meas_interval = 10;              // interval of steps at which to measure observables
-    wfPar.props = qName;                  // provide a list of propagators to be flowed
-    wfPar.bc = -1;                        // set boundary conditions to anti-periodic in time (bc = 1 will keep periodic)
-    //wfPar.output = "GaugeFlow";         // option to output gauge flow data separately
+    wfPar.steps = 10;                        // total number of evolution steps to perform
+    wfPar.step_size = 0.01;                  // size of one step in flow time/a^2
+    wfPar.meas_interval = 10;                // interval of steps at which to measure observables
+    wfPar.props = qName;                     // provide a list of propagators to be flowed
+    //wfPar.outPropStems = {"flowedquark1"}; // (optional) provide a list of stems to assign the output propagators + "_tXXX" flow time value
+    wfPar.bc = -1;                           // set boundary conditions to anti-periodic in time (bc = 1 will keep periodic)
+    //wfPar.output = "GaugeFlow";            // option to output gauge flow data separately
     application.createModule<MGradientFlow::WilsonFermionFlow>("FermionFlow",wfPar);
     // ///////////////////////////////////////////////////////////////////////
     

--- a/tests/Test_fermion_flow.cpp
+++ b/tests/Test_fermion_flow.cpp
@@ -1,0 +1,123 @@
+#include <Hadrons/Application.hpp>
+#include <Hadrons/Modules.hpp>
+
+using namespace Grid;
+using namespace Hadrons;
+
+int main(int argc, char *argv[])
+{
+    // initialization //////////////////////////////////////////////////////////
+    Grid_init(&argc, &argv);
+    HadronsLogError.Active(GridLogError.isActive());
+    HadronsLogWarning.Active(GridLogWarning.isActive());
+    HadronsLogMessage.Active(GridLogMessage.isActive());
+    HadronsLogIterative.Active(GridLogIterative.isActive());
+    HadronsLogDebug.Active(GridLogDebug.isActive());
+    LOG(Message) << "Grid initialized" << std::endl;
+    
+    // run setup ///////////////////////////////////////////////////////////////
+    Application              application;
+    double        mass    = .25;
+    
+    // global parameters
+    Application::GlobalPar globalPar;
+    globalPar.trajCounter.start    = 1500;
+    globalPar.trajCounter.end      = 1520;
+    globalPar.trajCounter.step     = 20;
+    globalPar.runId                = "test";
+    globalPar.genetic.maxGen       = 1000;
+    globalPar.genetic.maxCstGen    = 200;
+    globalPar.genetic.popSize      = 20;
+    globalPar.genetic.mutationRate = .1;
+    application.setPar(globalPar);
+    
+    // gauge field
+    application.createModule<MGauge::Random>("gauge");
+
+    // set fermion boundary conditions to be periodic space, antiperiodic time.
+    std::string boundary = "1 1 1 -1";
+    std::string twist = "0. 0. 0. 0.";
+
+    // point source
+    MSource::Point::Par ptPar;
+    ptPar.position = "0 0 0 0";
+    std:: string srcName  = "pt_0";
+    application.createModule<MSource::Point>(srcName, z2Par);
+
+    // point sink
+    MSink::Point::Par sinkPar;
+    sinkPar.mom = "0 0 0";
+    application.createModule<MSink::ScalarPoint>("sink", sinkPar);
+    
+    // action
+    MAction::DWF::Par actionPar;
+    actionPar.gauge = "gauge";
+    actionPar.Ls    = 12;
+    actionPar.M5    = 1.8;
+    actionPar.mass  = mass;
+    actionPar.boundary = boundary;
+    actionPar.twist = twist;
+    application.createModule<MAction::DWF>("DWF", actionPar);
+    
+    // solver
+    MSolver::RBPrecCG::Par solverPar;
+    solverPar.action       = "DWF";
+    solverPar.residual     = 1.0e-8;
+    solverPar.maxIteration = 10000;
+    application.createModule<MSolver::RBPrecCG>("CG",solverPar);
+
+    // propagator
+    MFermion::GaugeProp::Par quarkPar;
+    quarkPar.solver = "CG";
+    quarkPar.source = srcName;
+    std::vector<std::string> qName = {"Qpt_0"};
+    application.createModule<MFermion::GaugeProp>(qName[0], quarkPar);
+
+    // zero flow contractions
+    MContraction::Meson::Par mesPar;
+    mesPar.q1     = qName[0];
+    mesPar.q2     = qName[0];
+    mesPar.gammas = "all";
+    mesPar.sink   = "sink";
+    application.createModule<MContraction::Meson>("meson_t0.00",mesPar);
+
+    std::vector<std::string> results = {"meson_t0.00"}; // collect names of results to be written to file
+    
+    // ///////////////////////////////////////////////////////////////////////
+    // gradient flow on propagator ///////////////////////////////////////////
+    MGradientFlow::WilsonFermionFlow::Par wfPar;
+    wfPar.gauge = "gauge";
+    wfPar.steps = 10;                     // total number of evolution steps to perform
+    wfPar.step_size = 0.1;                // size of one step in flow time/a^2
+    wfPar.meas_interval = 10;              // interval of steps at which to measure observables
+    wfPar.props = qName;                  // provide a list of propagators to be flowed
+    wfPar.bc = -1;                        // set boundary conditions to anti-periodic in time (bc = 1 will keep periodic)
+    //wfPar.output = "GaugeFlow";         // option to output gauge flow data separately
+    application.createModule<MGradientFlow::WilsonFermionFlow>("FermionFlow",gfPar);
+    // ///////////////////////////////////////////////////////////////////////
+    
+    // positive flow contractions
+    MContraction::Meson::Par mesPar;
+    mesPar.q1     = "FermionFlow_q0_10";
+    mesPar.q2     = "FermionFlow_q0_10";
+    mesPar.gammas = "all";
+    mesPar.sink   = "sink";
+    application.createModule<MContraction::Meson>("meson_t0.10",mesPar);
+    results.push_back("meson_t0.10");
+
+    // save data
+    MIO::WriteResultGroup::Par wPar;
+    wPar.results = results;
+    wPar.output = "results";
+    application.createModule<MIO::WriteResultGroup>("WriteToFile",wPar);
+
+    // execution
+    application.saveParameterFile("FermionFlow.xml");
+    application.run();
+    
+    // epilogue
+    LOG(Message) << "Grid is finalizing now" << std::endl;
+    Grid_finalize();
+    
+    return EXIT_SUCCESS;
+}

--- a/tests/Test_gradient_flow.cpp
+++ b/tests/Test_gradient_flow.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
                                           */
     gfPar.gauge = "gauge";
     gfPar.steps = 10;                     // total number of evolution steps to perform
-    gfPar.step_size = 0.1;                // size of one step in flow time/a^2
+    gfPar.step_size = 0.01;               // size of one step in flow time/a^2
     gfPar.meas_interval = 1;              // interval of steps at which to measure observables
     gfPar.output = "WilsonFlow";         
     application.createModule<MGradientFlow::WilsonFlow>("WilsonFlow",gfPar);

--- a/tests/Test_gradient_flow.cpp
+++ b/tests/Test_gradient_flow.cpp
@@ -1,0 +1,60 @@
+#include <Hadrons/Application.hpp>
+#include <Hadrons/Modules.hpp>
+
+using namespace Grid;
+using namespace Hadrons;
+
+int main(int argc, char *argv[])
+{
+    // initialization //////////////////////////////////////////////////////////
+    Grid_init(&argc, &argv);
+    HadronsLogError.Active(GridLogError.isActive());
+    HadronsLogWarning.Active(GridLogWarning.isActive());
+    HadronsLogMessage.Active(GridLogMessage.isActive());
+    HadronsLogIterative.Active(GridLogIterative.isActive());
+    HadronsLogDebug.Active(GridLogDebug.isActive());
+    LOG(Message) << "Grid initialized" << std::endl;
+    
+    // run setup ///////////////////////////////////////////////////////////////
+    Application              application;
+    
+    // global parameters
+    Application::GlobalPar globalPar;
+    globalPar.trajCounter.start    = 1500;
+    globalPar.trajCounter.end      = 1520;
+    globalPar.trajCounter.step     = 20;
+    globalPar.runId                = "test";
+    globalPar.genetic.maxGen       = 1000;
+    globalPar.genetic.maxCstGen    = 200;
+    globalPar.genetic.popSize      = 20;
+    globalPar.genetic.mutationRate = .1;
+    application.setPar(globalPar);
+    
+    // gauge field
+    application.createModule<MGauge::Random>("gauge");
+
+    // ////////////////////////////////////////////////////////////////////////
+    // gradient flow on gauge field ///////////////////////////////////////////
+    MGradientFlow::WilsonFlow::Par gfPar; /* alternative actions: SymanzikFlow, 
+                                                                  ZeuthenFlow,
+                                                                  CustomFlow -> choose your own plaquette and rectangle coefficients
+                                                                                                gfPar.c_plaq  gfPar.c_rect
+                                          */
+    gfPar.gauge = "gauge";
+    gfPar.steps = 10;                     // total number of evolution steps to perform
+    gfPar.step_size = 0.1;                // size of one step in flow time/a^2
+    gfPar.meas_interval = 1;              // interval of steps at which to measure observables
+    gfPar.output = "WilsonFlow";         
+    application.createModule<MGradientFlow::WilsonFlow>("WilsonFlow",gfPar);
+    // ////////////////////////////////////////////////////////////////////////
+
+    // execution
+    application.saveParameterFile("WilsonFlow.xml");
+    application.run();
+    
+    // epilogue
+    LOG(Message) << "Grid is finalizing now" << std::endl;
+    Grid_finalize();
+    
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Adds modules for applying the gradient flow to gauge and propagator fields.

### Gauge Flow 
- **MGradientFlow::WilsonFlow**
  Applies the gradient flow to a gauge field with the Wilson action kernel
- **MGradientFlow::SymanzikFlow**
  Applies the gradient flow to a gauge field with the Symanzik action kernel
- **MGradientFlow::ZeuthenFlow**
  Applies the gradient flow to a gauge field with the Zeuthen kernel
- **MGradientFlow::CustomFlow**
  Applies the gradient flow to a gauge field with the PlaqPlusRectangle action kernel with custom inputs for the coefficients of the plaquette and rectangle terms

The flowed gauge field after the final flow time step is returned via `moduleName_U`.
  
All gauge flow modules create a **Results** object with the following gauge observables as functions of the flow time:
- `flowtime` : the values of the gradient flow time used for measurement (lattice units)
- `plaquette`, `rectangle`, `clover` Wilson loops
- `topocharge` : the topological charge
- `action` 
- `polyakovX`, `polyakovY`, `polyakovZ`, `polyakovT` : the Polyakov loop in each spacetime direction around the lattice
  
### Fermion Flow 
  - **MGradientFlow::WilsonFermionFlow**
    Applies the gradient flow to a (list of) propagator field(s) (also using the gauge field).

The flowed propagator fields at each chosen measurement step in the flow time are returned via `propagatorName_t<FlowTime>`. 

The fermion flow module also returns the same **Results** object with information on the gauge field. 

### Utils
For use in the above modules, an additional `Utils` header is included, containing:
- **ZeuthenGaugeAction** 
  The modified Symanzik aciton labelled Zeuthen popularly used in gradient flow studies
- **avgClover**
  A function for calculating the clover term of a gauge field.
- **avgPolyakovLoopMu**
  A function to compute the Polyakov loop in any mu direction of the gauge field.
- **Evolution**
  A class handling the Runge-Kutta procedure for the gradient flow evolution of gauge and propagator fields
   Credit to the authors of the WilsonFlow implementation in Grid (https://github.com/paboyle/Grid/blob/develop/Grid/qcd/smearing/WilsonFlow.h) for the original code for the gauge flow which I built upon in this class for further use with the propagator fields.

### Tests
Also included are two tests to demonstrate the use of the above modules:
- **Test_gradient_flow**
   Demonstrates the use of the Gauge Flow modules
- **Test_fermion_flow**
   Demonstrates the use of the Fermion Flow module