### PR TITLE
Tell utility binaries to recompile when libHadrons changes

### DIFF
--- a/utilities/Makefile.am
+++ b/utilities/Makefile.am
@@ -11,19 +11,25 @@ bin_PROGRAMS = \
 
 BatchDeflationBenchmark_SOURCES = BatchDeflationBenchmark.cpp
 BatchDeflationBenchmark_LDADD = -lHadrons -lGrid
+BatchDeflationBenchmark_DEPENDENCIES = $(top_builddir)/Hadrons/libHadrons.a
 
 HadronsXmlRun_SOURCES = HadronsXmlRun.cpp
 HadronsXmlRun_LDADD   = -lHadrons -lGrid
+HadronsXmlRun_DEPENDENCIES = $(top_builddir)/Hadrons/libHadrons.a
 
 HadronsXmlValidate_SOURCES = HadronsXmlValidate.cpp
 HadronsXmlValidate_LDADD   = -lHadrons -lGrid
+HadronsXmlValidate_DEPENDENCIES = $(top_builddir)/Hadrons/libHadrons.a
 
 HadronsFermionEP64To32_SOURCES  = EigenPackCast.cpp
 HadronsFermionEP64To32_CXXFLAGS = $(AM_CXXFLAGS) -DFIN=WilsonImplD::FermionField -DFOUT=WilsonImplF::FermionField
 HadronsFermionEP64To32_LDADD    = -lHadrons -lGrid
+HadronsFermionEP64To32_DEPENDENCIES = $(top_builddir)/Hadrons/libHadrons.a
 
 HadronsContractor_SOURCES = Contractor.cpp
 HadronsContractor_LDADD   = -lHadrons -lGrid
+HadronsContractor_DEPENDENCIES = $(top_builddir)/Hadrons/libHadrons.a
 
 HadronsContractorBenchmark_SOURCES = ContractorBenchmark.cpp
 HadronsContractorBenchmark_LDADD   = -lHadrons -lGrid
+HadronsContractorBenchmark_DEPENDENCIES = $(top_builddir)/Hadrons/libHadrons.a


### PR DESCRIPTION
Currently the utility binaries do not recompile when changes are made to Hadrons. Than can be confusing for users since code edits are not reflected in the runtime binaries without first running `make clean` or `rm utilities/<utility>`.

This PR tells autotools that the utilities are dependent on `libHadrons.a`, which triggers the utilities to rebuild when `libHadrons.a` changes.
