### PR TITLE
Three-point contractions with arbitrary gamma combinations and list of momentum projection

### DIFF
--- a/Hadrons/Modules/MContraction/Gamma3pt.cpp
+++ b/Hadrons/Modules/MContraction/Gamma3pt.cpp
@@ -18,7 +18,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
  *
- * See the full license in the file "LICENSE" in the top level distribution 
+ * See the full license in the file "LICENSE" in the top level distribution
  * directory.
  */
 

--- a/Hadrons/Modules/MContraction/Gamma3pt.hpp
+++ b/Hadrons/Modules/MContraction/Gamma3pt.hpp
@@ -21,7 +21,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
  *
- * See the full license in the file "LICENSE" in the top level distribution 
+ * See the full license in the file "LICENSE" in the top level distribution
  * directory.
  */
 
@@ -34,6 +34,31 @@
 #include <Hadrons/Module.hpp>
 #include <Hadrons/ModuleFactory.hpp>
 #include <Hadrons/Serialization.hpp>
+#include <Grid/algorithms/blas/MomentumProject.h>
+
+
+// TODO: When traceColour and traceSpin are implemented in Grid, remove these lines
+NAMESPACE_BEGIN(Grid);
+
+#define GRID_UNOP(name)   name
+#define GRID_DEF_UNOP(op, name)						\
+  template <typename T1, typename std::enable_if<is_lattice<T1>::value||is_lattice_expr<T1>::value,T1>::type * = nullptr> \
+  inline auto op(const T1 &arg) ->decltype(LatticeUnaryExpression<GRID_UNOP(name),T1>(GRID_UNOP(name)(), arg)) \
+  {									\
+    return     LatticeUnaryExpression<GRID_UNOP(name),T1>(GRID_UNOP(name)(), arg); \
+  }
+
+GridUnopClass(UnaryTraceColour, traceIndex<ColourIndex>(a));
+GridUnopClass(UnaryTraceSpin, traceIndex<SpinIndex>(a));
+
+GRID_DEF_UNOP(traceColour, UnaryTraceColour);
+GRID_DEF_UNOP(traceSpin, UnaryTraceSpin);
+
+#undef GRID_UNOP
+#undef GRID_DEF_UNOP
+
+NAMESPACE_END(Grid);
+
 
 BEGIN_HADRONS_NAMESPACE
 
@@ -42,62 +67,36 @@ BEGIN_HADRONS_NAMESPACE
  *
  * Schematic:
  *
- *             q2           q3
- *        /----<------*------<----¬
- *       /          gamma          \
- *      /                           \
- *   i *                            * f
- *      \                          /
- *       \                        /
- *        \----------->----------/
- *                   q1
+ *                   q2           q3
+ *              /----<------*------<----¬
+ *             /           gV            \
+ *            /                           \
+ *   i, gSrc *                            * f, gSnk
+ *            \                          /
+ *             \                        /
+ *              \----------->----------/
+ *                          q1
  *
- *      trace(g5*q1*adj(q2)*g5*gamma*q3)
- * 
+ *      trace(gSnk*q1Snk*(adj(gSrc)*g5)*adj(q2)*(g5*gV)*q3)
+ *
  *  options:
  *   - q1: sink smeared propagator, source at i
  *   - q2: propagator, source at i
  *   - q3: propagator, source at f
- *   - gammas: gamma matrices to insert
- *             (space-separated strings e.g. "GammaT GammaX GammaY") 
+ *   - gamma: gamma matrices to insert as vector of space-separated strings,
+ *                  gSnk     gV   gSrc
+ *              {"GammaT GammaX GammaY",
+ *               "Gamma5    all Gamma5",
+ *               "GammaX GammaY GammaT"}
  *   - tSnk: sink position for propagator q1.
+ *   - momProjector: Name of module to do momentum projection.
+ *                   If empty, project to zero momentum only.
+ *   - output: Name of output file.
+ *             If empty, do not save.
  *
  */
 
-/* 11/07/2024 (AP): This module has been extended to allow different gamma
- * matrices at the source and the sink
- * ----------------------------------------------------
- * Previous version input parameters
- * <options>
- *  <q1>q1</q1>
- *  <q2>q2</q2>
- *  <q3>q3</q3>
- *  <gamma>all</gamma>
- *  <tSnk>16</tSnk>
- *  <output>3pt</output>
- * </options>
- * 
- * is equivalent to the code below in the new version
- * 
- * <options>
- *  <q1>q1</q1>
- *  <q2>q2</q2>
- *  <q3>q3</q3>
- *  <gamma>
- *    <vertex>all</vertex>
- *    <source>Gamma5</source>
- *    <sink>Gamma5</sink>
- *  </gamma>
- *  <tSnk>16</tSnk>
- *  <save4d>false</save4d>
- *  <output>3pt</output>
- * </options>
- * 
- * HDF5 metadata is changed as well to reflect that, hopefully that part
- * is self-explanatory.
- */
-
-/******************************************************************************
+ /******************************************************************************
  *                               Gamma3pt                                     *
  ******************************************************************************/
 BEGIN_MODULE_NAMESPACE(MContraction)
@@ -105,23 +104,14 @@ BEGIN_MODULE_NAMESPACE(MContraction)
 class Gamma3ptPar: Serializable
 {
 public:
-    class GammaPar: Serializable
-    {
-    public:
-        GRID_SERIALIZABLE_CLASS_MEMBERS(GammaPar,
-                                        std::string, vertex,
-                                        std::string, source,
-                                        std::string, sink);
-    };
-public:
     GRID_SERIALIZABLE_CLASS_MEMBERS(Gamma3ptPar,
-                                    std::string,  q1,
-                                    std::string,  q2,
-                                    std::string,  q3,
-                                    GammaPar,  gamma,
-                                    unsigned int, tSnk,
-                                    bool, save4d,
-                                    std::string,  output);
+                                    std::string,                q1,
+                                    std::string,                q2,
+                                    std::string,                q3,
+                                    std::vector<std::string>,   gamma,
+                                    unsigned int,               tSnk,
+                                    std::string,                momProjector,
+                                    std::string,                output);
 };
 
 template <typename FImpl1, typename FImpl2, typename FImpl3>
@@ -129,24 +119,29 @@ class TGamma3pt: public Module<Gamma3ptPar>
 {
     FERM_TYPE_ALIASES(FImpl1, 1);
     FERM_TYPE_ALIASES(FImpl2, 2);
-    FERM_TYPE_ALIASES(FImpl3, 3); 
+    FERM_TYPE_ALIASES(FImpl3, 3);
+    using SpinField = SpinMatrixField1;
+    using PhaseField = ComplexField1;
+    using MPType = MomentumProject<PhaseField, PhaseField>;
+
 public:
     class GammaTriad: Serializable
     {
-    public:
-        GRID_SERIALIZABLE_CLASS_MEMBERS(GammaTriad,
-                                        Gamma::Algebra, vertex, 
-                                        Gamma::Algebra, source, 
-                                        Gamma::Algebra, sink);
+        public:
+            GRID_SERIALIZABLE_CLASS_MEMBERS(GammaTriad,
+                                            Gamma::Algebra, vertex,
+                                            Gamma::Algebra, source,
+                                            Gamma::Algebra, sink);
     };
     class Result: Serializable
     {
-    public:
-        GRID_SERIALIZABLE_CLASS_MEMBERS(Result,
-                                        GammaTriad, gamma,
-                                        std::vector<Complex>, corr);
+        public:
+            GRID_SERIALIZABLE_CLASS_MEMBERS(Result,
+                std::vector<GammaTriad>, gamma,
+                std::vector<std::vector<int>>, momentum,
+                std::vector<std::vector<std::vector<Complex>>>, corr);
     };
-public:
+
     // constructor
     TGamma3pt(const std::string name);
     // destructor
@@ -155,14 +150,17 @@ public:
     virtual std::vector<std::string> getInput(void);
     virtual std::vector<std::string> getOutput(void);
     virtual std::vector<std::string> getOutputFiles(void);
-    static std::vector<Gamma::Algebra> parseGammaString(const std::string &gammaString);
 protected:
     // setup
     virtual void setup(void);
     // execution
     virtual void execute(void);
 private:
-    std::vector<GammaTriad> gammaList_;
+        std::vector<GammaTriad> allGammaComb_;          // Vector of all gamma combinations
+        std::vector<Gamma::Algebra> allGammaSinks_;     // Vector of all gammas at the sink
+        std::vector<Gamma::Algebra> allGammaVertices_;  // Vector of all gammas at the vertex
+        std::vector<Gamma::Algebra> allGammaSources_;   // Vector of all gammas at the source
+        bool isLegacy_;
 };
 
 MODULE_REGISTER_TMP(Gamma3pt, ARG(TGamma3pt<FIMPL, FIMPL, FIMPL>), MContraction);
@@ -181,7 +179,13 @@ template <typename FImpl1, typename FImpl2, typename FImpl3>
 std::vector<std::string> TGamma3pt<FImpl1, FImpl2, FImpl3>::getInput(void)
 {
     std::vector<std::string> in = {par().q1, par().q2, par().q3};
-    
+
+    if (!par().momProjector.empty())
+    {
+        in.push_back(par().momProjector);
+        in.push_back(par().momProjector + "_momList");
+    }
+
     return in;
 }
 
@@ -190,11 +194,6 @@ std::vector<std::string> TGamma3pt<FImpl1, FImpl2, FImpl3>::getOutput(void)
 {
     std::vector<std::string> out = {getName()};
 
-    if (par().save4d)
-    {
-        out.push_back(getName() + "_4d");
-    }
-    
     return out;
 }
 
@@ -202,125 +201,278 @@ template <typename FImpl1, typename FImpl2, typename FImpl3>
 std::vector<std::string> TGamma3pt<FImpl1, FImpl2, FImpl3>::getOutputFiles(void)
 {
     std::vector<std::string> output;
-    
+
     if (!par().output.empty())
         output.push_back(resultFilename(par().output));
-    
+
     return output;
 }
 
 // setup ///////////////////////////////////////////////////////////////////////
 template <typename FImpl1, typename FImpl2, typename FImpl3>
 void TGamma3pt<FImpl1, FImpl2, FImpl3>::setup(void)
+/*
+ * Fill allGammaComb_ with all combinations implied by par().gamma.
+ *
+ * Input example 1:
+ *      If strGammas = 'GammaX GammaY Gamma5', the function adds one entry
+ *      to allGammaComb_, GammaTriad(source=Gamma5, vertex=GammaY, sink=GammaX).
+ *
+ * Input example 2:
+ *      If strGammas = 'all GammaY all', the function adds one entry per
+ *      gamma function combination (cartesian product of every gamma matrix at source
+ *      and sink). 'all' can be included either at source, vertex, and/or sink.
+ */
 {
-    std::vector<Gamma::Algebra> vGammaList, srcGammaList, snkGammaList;
+    isLegacy_ = par().momProjector.empty();
 
-    vGammaList = parseGammaString(par().gamma.vertex);
-    srcGammaList = parseGammaString(par().gamma.source);
-    snkGammaList = parseGammaString(par().gamma.sink);
-    gammaList_.clear();
-    for (auto gV: vGammaList)
-    for (auto gSrc: srcGammaList)
-    for (auto gSnk: snkGammaList)
-    {
-        GammaTriad t;
+    const unsigned int nd = env().getNd() - 1;
 
-        t.vertex = gV;
-        t.source = gSrc;
-        t.sink = gSnk;
-        gammaList_.push_back(t);
-    }
-    if (par().save4d)
+    auto parseInput = [](const std::string strGammas)
     {
-        envCreate(std::vector<ComplexField1>, getName() + "_4d", 1, 
-                  gammaList_.size(), envGetGrid(ComplexField1));
-    }
-    else
-    {
-        envTmpLat(LatticeComplex, "c");
-    }
-    envCreate(HadronsSerializable, getName(), 1, 0);
-}
-
-template <typename FImpl1, typename FImpl2, typename FImpl3>
-std::vector<Gamma::Algebra> 
-TGamma3pt<FImpl1, FImpl2, FImpl3>::parseGammaString(const std::string &gammaString)
-{
-    std::vector<Gamma::Algebra> gammaList;
-    // Determine gamma matrices to insert
-    if (gammaString == "all")
-    {
-        // Do all contractions.
-        for (unsigned int i = 1; i < Gamma::nGamma; i += 2)
+        // strGammas = 'sink vertex source' -> listGammas = ['sink', 'vertex', 'source']
+        std::vector<std::string> listGammas;
+        std::istringstream iss(strGammas);
+        std::string gamma;
+        while (iss >> gamma)
         {
-            gammaList.push_back((Gamma::Algebra)i);
+            listGammas.push_back(gamma);
+        }
+        // Check the input/parsing is correct
+        if (listGammas.size() > 3)
+        {
+            HADRONS_ERROR(Argument, "Too many gamma matrices! Provide sink vertex source gammas");
+        }
+        else if (listGammas.size() < 3)
+        {
+            HADRONS_ERROR(Argument, "Too few gamma matrices! Provide sink vertex source gammas");
+        }
+        return listGammas;
+    };
+
+    auto expandAll = [](const std::string gamma)
+    {
+        std::vector<Gamma::Algebra> v;
+        if (gamma == "all")
+        {
+            // Do all gamma matrices.
+            for (unsigned int i = 1; i < Gamma::nGamma; i += 2)
+            {
+                v.push_back((Gamma::Algebra)i);
+            }
+        }
+        else
+        {
+            // Parse individual contractions from input string.
+            for (auto g : strToVec<Gamma::Algebra>(gamma))
+            {
+                v.push_back(g);
+            }
+        }
+        return v;
+    };
+
+    auto cartesianProduct = [](
+        const std::vector<Gamma::Algebra> &sinks,
+        const std::vector<Gamma::Algebra> &vertices,
+        const std::vector<Gamma::Algebra> &sources)
+    {
+        // Cartesian product
+        std::vector<GammaTriad> list;
+        for (auto gSrc : sources)
+        {
+            for (auto gSnk : sinks)
+            {
+                for (auto gVtx : vertices)
+                {
+                    GammaTriad t;
+                    t.source = gSrc;
+                    t.vertex = gVtx;
+                    t.sink = gSnk;
+                    list.push_back(t);
+                }
+            }
+        }
+        return list;
+    };
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Expand 'all' and create full list of gamma matrix combinations to compute
+    /////////////////////////////////////////////////////////////////////////////
+
+    allGammaComb_.clear();
+    allGammaSinks_.clear();
+    allGammaSources_.clear();
+    allGammaVertices_.clear();
+    for (auto strGammas : par().gamma)
+    {
+        std::vector<Gamma::Algebra> sinks;
+        std::vector<Gamma::Algebra> vertices;
+        std::vector<Gamma::Algebra> sources;
+
+        std::vector<std::string> gammaTriad = parseInput(strGammas);
+
+        // Add gammas to sets used in sink, vertex, and source of contraction
+
+        for (const auto &gSnk : expandAll(gammaTriad[0]))
+        {
+            sinks.push_back(gSnk);
+            if (std::find(allGammaSinks_.begin(), allGammaSinks_.end(), gSnk) == allGammaSinks_.end())
+            {
+                allGammaSinks_.push_back(gSnk);
+            }
+        }
+
+        for (const auto &gV : expandAll(gammaTriad[1]))
+        {
+            vertices.push_back(gV);
+            if (std::find(allGammaVertices_.begin(), allGammaVertices_.end(), gV) == allGammaVertices_.end())
+            {
+                allGammaVertices_.push_back(gV);
+            }
+        }
+
+        for (const auto &gSrc : expandAll(gammaTriad[2]))
+        {
+            sources.push_back(gSrc);
+            if (std::find(allGammaSources_.begin(), allGammaSources_.end(), gSrc) == allGammaSources_.end())
+            {
+                allGammaSources_.push_back(gSrc);
+            }
+        }
+
+        for (const auto& e : cartesianProduct(sinks, vertices, sources))
+        {
+            if (std::find(allGammaComb_.begin(), allGammaComb_.end(), e) == allGammaComb_.end())
+            {
+                allGammaComb_.push_back(e);
+            }
         }
     }
-    else
-    {
-        // Parse individual contractions from input string.
-        gammaList = strToVec<Gamma::Algebra>(gammaString);
-    }
 
-    return gammaList;
+    /////////////////////
+    // Allocate variables
+    /////////////////////
+    {
+        envTmpLat(PropagatorField1, "q2Adj");
+        envTmpLat(PropagatorField1, "prodSrc");
+        envTmpLat(SpinField, "spinField");
+        envTmpLat(PhaseField, "contraction");
+
+        envCreate(HadronsSerializable, getName(), 1, 0);
+    }
 }
 
 // execution ///////////////////////////////////////////////////////////////////
 template <typename FImpl1, typename FImpl2, typename FImpl3>
 void TGamma3pt<FImpl1, FImpl2, FImpl3>::execute(void)
 {
-    LOG(Message) << "Computing 3pt contractions '" << getName() << "' using"
-                 << " quarks '" << par().q1 << "' (spectator), '" << par().q2 << "', and '"
-                 << par().q3 << "'" << std::endl;
-    LOG(Message) << "Vertices: " << par().gamma.vertex << std::endl;
-    LOG(Message) << " Sources: " << par().gamma.source << std::endl;
-    LOG(Message) << "   Sinks: " << par().gamma.sink << std::endl;
-    LOG(Message) << "   Total: " << gammaList_.size() << " correlator(s)" << std::endl;
-    if (par().save4d)
-    {
-        LOG(Message) << "4D correlators are kept in memory" << std::endl;
-    }
+    const unsigned int nt = env().getDim(Tp);
 
-    auto                        &q1 = envGet(SlicedPropagator1, par().q1);
-    auto                        &q2 = envGet(PropagatorField2, par().q2);
-    auto                        &q3 = envGet(PropagatorField2, par().q3);
-    Gamma                       g5(Gamma::Algebra::Gamma5);
-    ComplexField1               *pt;
-    std::vector<TComplex>       buf;
-    std::vector<Result>         result;
-    int                         nt = env().getDim(Tp);
-    SitePropagator1             q1Snk = q1[par().tSnk];
-
-    for (unsigned int i = 0; i < gammaList_.size(); ++i)
-    {
-        if (par().save4d)
-        {
-            auto &vec = envGet(std::vector<ComplexField1>, getName() + "_4d");
-            pt = &(vec[i]);
-        }
-        else
-        {
-            envGetTmp(ComplexField1, c);
-            pt = &c;
-        }
-
-        Gamma gV(gammaList_[i].vertex), gSrc(gammaList_[i].source), 
-              gSnk(gammaList_[i].sink);
-        Result r;
-        
-        (*pt) = trace(gSnk*q1Snk*(adj(gSrc)*g5)*adj(q2)*(g5*gV)*q3);
-        r.gamma = gammaList_[i];
-        r.corr.resize(nt);
-        sliceSum(*pt, buf, Tp);
-        for (unsigned int t = 0; t < buf.size(); ++t)
-        {
-            r.corr[t] = TensorRemove(buf[t]);
-        }
-        result.push_back(r);
-    }
-    saveResult(par().output, "gamma3pt", result);
+    Gamma g5(Gamma::Algebra::Gamma5);
     auto &out = envGet(HadronsSerializable, getName());
+    auto &q1 = envGet(SlicedPropagator1, par().q1);
+    auto &q2 = envGet(PropagatorField2, par().q2);
+    auto &q3 = envGet(PropagatorField3, par().q3);
+    SitePropagator1 q1Snk = q1[par().tSnk];
+
+    LOG(Message) << "Computing 3pt contractions '" << getName() << "' using"
+                << " quarks '" << par().q1 << "' (spectator), '" << par().q2 << "', and '"
+                << par().q3 << "'" << std::endl;
+    LOG(Message) << "   Total: " << allGammaComb_.size() << " correlator(s)" << std::endl;
+
+    // Allocate space for results, then index assign them
+
+    Result result;
+    result.gamma = allGammaComb_;
+    result.corr.resize(allGammaComb_.size());
+
+    if (isLegacy_)
+    {
+        result.momentum = {{0, 0, 0}};
+    }
+    else
+    {
+        result.momentum = envGet(std::vector<std::vector<int>>, par().momProjector + "_momList");
+    }
+
+    envGetTmp(PropagatorField1, q2Adj);
+    envGetTmp(PropagatorField1, prodSrc);
+    envGetTmp(SpinField, spinField);
+    envGetTmp(PhaseField, contraction);
+    std::vector<typename PhaseField::scalar_object> fourierModes;
+
+    startTimer("Trace");
+    q2Adj = adj(q2);
+    stopTimer("Trace");
+
+    // Outer loops reuse partial products to reduce multiplications
+    for (auto iSrc : allGammaSources_)
+    {
+        startTimer("Trace");
+        Gamma gSrc(iSrc);
+        prodSrc = q1Snk * (adj(gSrc) * g5) * q2Adj;
+        stopTimer("Trace");
+
+        for (auto iV : allGammaVertices_)
+        {
+            startTimer("Trace");
+            Gamma gV(iV);
+            spinField = traceColour(prodSrc * (g5 * gV) * q3);
+            stopTimer("Trace");
+
+            for (auto iSnk : allGammaSinks_)
+            {
+                // Locate the index of the (iSnk, iV, iSrc) combination
+                GammaTriad current;
+                current.sink = iSnk;
+                current.vertex = iV;
+                current.source = iSrc;
+
+                auto loc = std::find(allGammaComb_.begin(), allGammaComb_.end(), current);
+                if (loc == allGammaComb_.end())
+                {
+                    continue;
+                }
+                unsigned int gammaIdx = static_cast<unsigned int>(std::distance(allGammaComb_.begin(), loc));
+
+                LOG(Message) << "Source: " << iSrc << " | "
+                            << "Vertex: " << iV << " | "
+                            << "Sink: "   << iSnk   << std::endl;
+
+                startTimer("Trace");
+                Gamma gSnk(iSnk);
+                contraction = traceSpin(gSnk * spinField);
+                stopTimer("Trace");
+
+                startTimer("FT");
+                if (isLegacy_)
+                {
+                    sliceSum(contraction, fourierModes, Tp);
+                }
+                else
+                {
+                    auto &momProjector = envGet(MPType, par().momProjector);
+                    momProjector.Project(contraction, fourierModes);
+                }
+                stopTimer("FT");
+
+                startTimer("Result");
+                result.corr[gammaIdx].resize(result.momentum.size());
+                for (unsigned int m = 0; m < result.momentum.size(); ++m)
+                {
+                    const auto *first = fourierModes.data() + nt * m;
+                    const auto *last  = first + nt;
+                    result.corr[gammaIdx][m].assign(first, last);
+                }
+                stopTimer("Result");
+            }
+        }
+    }
+    startTimer("I/O");
     out = result;
+    saveResult(par().output, "gamma3pt", result);
+    stopTimer("I/O");
 }
 
 END_MODULE_NAMESPACE

--- a/Hadrons/Modules/MSink/Point0.cpp
+++ b/Hadrons/Modules/MSink/Point0.cpp
@@ -18,11 +18,12 @@
  * You should have received a copy of the GNU General Public License
  * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
  *
- * See the full license in the file "LICENSE" in the top level distribution 
+ * See the full license in the file "LICENSE" in the top level distribution
  * directory.
  */
 
 /*  END LEGAL */
+// #include <Hadrons/Modules/MSink/Point0.hpp>
 #include <Hadrons/Modules/MSink/Point0.hpp>
 
 using namespace Grid;
@@ -30,3 +31,4 @@ using namespace Hadrons;
 using namespace MSink;
 
 template class HADRONS_NAMESPACE::MSink::TPoint0<ScalarImplCR::Field>;
+template class HADRONS_NAMESPACE::MSink::TPoint0<FIMPL::PropagatorField>;

--- a/Hadrons/Modules/MSink/Point0.hpp
+++ b/Hadrons/Modules/MSink/Point0.hpp
@@ -18,7 +18,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
  *
- * See the full license in the file "LICENSE" in the top level distribution 
+ * See the full license in the file "LICENSE" in the top level distribution
  * directory.
  */
 
@@ -35,7 +35,7 @@ BEGIN_HADRONS_NAMESPACE
 /******************************************************************************
  *                Point sink just picking the origin in space                 *
  *                                                                            *
- * e.g. sink(field(xvec, t)) = field(0, t)                                    * 
+ * e.g. sink(field(xvec, t)) = field(0, t)                                    *
  ******************************************************************************/
 BEGIN_MODULE_NAMESPACE(MSink)
 
@@ -62,6 +62,7 @@ public:
 };
 
 MODULE_REGISTER_TMP(ScalarPoint0, TPoint0<ScalarImplCR::Field>, MSink);
+MODULE_REGISTER_TMP(Point0, TPoint0<FIMPL::PropagatorField>, MSink);
 
 /******************************************************************************
  *                            TPoint0 implementation                          *
@@ -77,7 +78,7 @@ template <typename Field>
 std::vector<std::string> TPoint0<Field>::getInput(void)
 {
     std::vector<std::string> in;
-    
+
     return in;
 }
 
@@ -85,7 +86,7 @@ template <typename Field>
 std::vector<std::string> TPoint0<Field>::getOutput(void)
 {
     std::vector<std::string> out = {getName()};
-    
+
     return out;
 }
 
@@ -117,7 +118,7 @@ void TPoint0<Field>::execute(void)
             origin[nd - 1] = t;
             res[t] = peekSite(field, origin);
         }
-        
+
         return res;
     };
     envGet(SinkFn, getName()) = sink;

--- a/Hadrons/Modules/MUtilities/MomentumProjectorSphere.cpp
+++ b/Hadrons/Modules/MUtilities/MomentumProjectorSphere.cpp
@@ -1,0 +1,32 @@
+/*
+* MomentumProject.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+*
+* Copyright (C) 2015 - 2023
+*
+* Author: Teseo San Jose <teseo.sanjose@ed.ac.uk>
+*
+* Hadrons is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Hadrons is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+*
+* See the full license in the file "LICENSE" in the top level distribution
+* directory.
+*/
+
+/*  END LEGAL */
+#include <Hadrons/Modules/MUtilities/MomentumProjectorSphere.hpp>
+
+using namespace Grid;
+using namespace Hadrons;
+using namespace MUtilities;
+
+template class HADRONS_NAMESPACE::MUtilities::TMomentumProjectorSphere<FIMPL::ComplexField, FIMPL::ComplexField>;

--- a/Hadrons/Modules/MUtilities/MomentumProjectorSphere.hpp
+++ b/Hadrons/Modules/MUtilities/MomentumProjectorSphere.hpp
@@ -1,0 +1,213 @@
+/*
+* MomentumProjectorSphere.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+*
+* Copyright (C) 2015 - 2023
+*
+* Author: Teseo San Jose <teseo.sanjose@ed.ac.uk>
+*
+* Hadrons is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Hadrons is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+*
+* See the full license in the file "LICENSE" in the top level distribution
+* directory.
+*/
+
+/*  END LEGAL */
+
+#ifndef Hadrons_MUtilities_MomentumProjectorSphere_hpp_
+#define Hadrons_MUtilities_MomentumProjectorSphere_hpp_
+
+#include <Hadrons/Global.hpp>
+#include <Hadrons/Module.hpp>
+#include <Hadrons/ModuleFactory.hpp>
+#include <Hadrons/Serialization.hpp>
+#include <Grid/algorithms/blas/MomentumProject.h>
+
+BEGIN_HADRONS_NAMESPACE
+
+/******************************************************************************
+ *                              MomentumProjectorSphere                      *
+ *****************************************************************************/
+BEGIN_MODULE_NAMESPACE(MUtilities)
+
+class MomentumProjectorSpherePar: Serializable
+{
+    public:
+        GRID_SERIALIZABLE_CLASS_MEMBERS(MomentumProjectorSpherePar,
+                                        unsigned int, maxFourier);
+};
+
+template<typename Field, typename ComplexField>
+class TMomentumProjectorSphere: public Module<MomentumProjectorSpherePar>
+{
+public:
+    using MPType = MomentumProject<Field, ComplexField>;
+    // constructor
+    TMomentumProjectorSphere(const std::string name);
+    // destructor
+    virtual ~TMomentumProjectorSphere(void) {};
+    // dependency relation
+    virtual std::vector<std::string> getInput(void);
+    virtual std::vector<std::string> getOutput(void);
+    //static methods
+    static void fillMomList(
+        std::vector<std::vector<int>> &momList, // TODO: Change to Grid::Coordinate?
+        const unsigned int maxFourier,
+        const unsigned int nd
+    );
+protected:
+    // setup
+    virtual void setup(void);
+    // execution
+    virtual void execute(void);
+};
+
+MODULE_REGISTER_TMP(MPScalar, ARG(TMomentumProjectorSphere<FIMPL::ComplexField, FIMPL::ComplexField>), MUtilities);
+
+/******************************************************************************
+ *                       TMomentumProjectorSphere implementation              *
+ ******************************************************************************/
+// constructor /////////////////////////////////////////////////////////////////
+template<typename Field, typename ComplexField>
+TMomentumProjectorSphere<Field, ComplexField>::TMomentumProjectorSphere(const std::string name)
+: Module<MomentumProjectorSpherePar>(name)
+{}
+
+// dependencies/products ///////////////////////////////////////////////////////
+template<typename Field, typename ComplexField>
+std::vector<std::string> TMomentumProjectorSphere<Field, ComplexField>::getInput(void)
+{
+    std::vector<std::string> in;
+
+    return in;
+}
+
+template<typename Field, typename ComplexField>
+std::vector<std::string> TMomentumProjectorSphere<Field, ComplexField>::getOutput(void)
+{
+    std::vector<std::string> out = {getName(), getName() + "_momList", getName() + "_phases"};
+
+    return out;
+}
+
+// setup ///////////////////////////////////////////////////////////////////////
+template<typename Field, typename ComplexField>
+void TMomentumProjectorSphere<Field, ComplexField>::setup(void)
+/*
+ * Fill list of momenta to compute. Allocate phases, initialize classes.
+ */
+{
+    envTmpLat(ComplexField, "coor");
+
+    // MomentumProject instance
+    env().template createObject<MPType>(getName(), Environment::Storage::standard, 0);
+
+    // List of momenta
+    const unsigned int nd = env().getNd() - 1;
+    envCreate(std::vector<std::vector<int>>, getName() + "_momList", 1, 0);
+    auto &momList = envGet(std::vector<std::vector<int>>, getName() + "_momList");
+    fillMomList(momList, par().maxFourier, nd);
+
+    // Phases
+    envCreate(std::vector<ComplexField>, getName() + "_phases", 1, momList.size(), envGetGrid(ComplexField));
+}
+
+// static /////////////////////////////////////////////////////////////////////
+template<typename Field, typename ComplexField>
+void TMomentumProjectorSphere<Field, ComplexField>::fillMomList(
+    std::vector<std::vector<int>> &momList,
+    const unsigned int maxFourier,
+    const unsigned int nd)
+{
+    auto indexToMom = [](std::vector<int> &mom, const unsigned int i, const unsigned int maxFourier, const unsigned int nd)
+    {
+        // Assign momentum given index following the lexicographic rules. Row major indexing.
+        const unsigned int size = 2*maxFourier + 1;
+
+        mom.resize(nd);
+        unsigned int buf = i;
+        for (int mu = nd - 1; mu >= 0; --mu)
+        {
+            mom[mu]  = static_cast<int>(buf % size) - static_cast<int>(maxFourier);
+            buf     /= size;
+        }
+    };
+
+    auto euclideanDistance = [](const std::vector<int> &mom)
+    {
+        // Return Euclidean distance of a momentum 3-vector.
+        double mod = 0;
+        for (auto p : mom)
+        {
+            mod += static_cast<double>(p * p);
+        }
+        return sqrt(mod);
+    };
+
+    // Total number of Fourier modes in a cube
+    unsigned int nMom = 1;
+    const unsigned int momSize = 2*maxFourier + 1;
+    for (unsigned int d = 0; d < nd; ++d)
+    {
+        nMom *= momSize;
+    }
+
+    // Gather only modes inside a sphere of radius <= maxFourier
+    for (unsigned int m = 0; m < nMom; ++m)
+    {
+        std::vector<int> mom;
+        indexToMom(mom, m, maxFourier, nd);
+        if (euclideanDistance(mom) <= static_cast<double>(maxFourier))
+        {
+            momList.push_back(mom);
+        }
+    }
+}
+
+// execution ///////////////////////////////////////////////////////////////////
+template<typename Field, typename ComplexField>
+void TMomentumProjectorSphere<Field, ComplexField>::execute(void)
+{
+    Complex i(0.0,1.0);
+    envGetTmp(ComplexField, coor);
+
+    auto &MP = envGet(MPType, getName());
+    auto &phases = envGet(std::vector<ComplexField>, getName() + "_phases");
+    auto &momList = envGet(std::vector<std::vector<int>>, getName() + "_momList");
+
+    startTimer("Phases");
+    for (unsigned int m = 0; m < momList.size(); ++m)
+    {
+        ComplexField& ph = phases[m];
+        ph = Zero();
+        const auto &p = momList[m];
+        for(unsigned int mu = 0; mu < p.size(); ++mu)
+        {
+            LatticeCoordinate(coor, mu);
+            ph = ph + (static_cast<Real>(p[mu]) / static_cast<Real>(env().getDim(mu))) * coor;
+        }
+        ph = exp(static_cast<Real>(2*M_PI)*i*ph);
+    }
+    stopTimer("Phases");
+
+    startTimer("ImportPhases");
+    MP.Allocate(momList.size(), env().getGrid());
+    MP.ImportMomenta(phases);
+    stopTimer("ImportPhases");
+}
+
+END_MODULE_NAMESPACE
+
+END_HADRONS_NAMESPACE
+
+#endif  // Hadrons_MUtilities_MomentumProjectorSphere_hpp_


### PR DESCRIPTION
## Modified files

- **MContraction::Gamma3pt**
   The program now accepts any gamma matrix combination and projects to a list of momenta with the help of an external module. Faster Wick contractions and Fourier transforms.
- **MSink::Point0**
   Added class for FIMPL::PropagatorField.

## New files

- **MUtilities::MomentumProjectorSphere**
   It projects to the list of all Fourier modes within a sphere of certain radius. It serves as a wrapper for the MomentumProject class implemented by @paboyle in [Grid](https://github.com/paboyle/Grid).