### PR TITLE
Use GaugeGroup API for ColdConfiguration instead of the GaugeImpl one

### DIFF
--- a/Hadrons/Modules/MGauge/Unit.hpp
+++ b/Hadrons/Modules/MGauge/Unit.hpp
@@ -99,7 +99,7 @@ void TUnit<GImpl>::execute(void)
     LOG(Message) << "Creating unit gauge configuration" << std::endl;
     
     auto &U = envGet(GaugeField, getName());
-    GImpl::ColdConfiguration(rng4d(), U);
+    Group::ColdConfiguration(U);
 }
 
 END_MODULE_NAMESPACE


### PR DESCRIPTION
The RNG is not needed anymore by ColdConfiguration, but the GImpl API still requires it. And when that API is used in the MGauge::Unit module, it generates misleading messages that the RNG is used. This PR fixes this issue by using the GaugeGroup API of ColdConfiguration instead, that accepts only one argument (doesn't require the RNG).